### PR TITLE
Fix queryString in logs

### DIFF
--- a/backend/src/logging.ts
+++ b/backend/src/logging.ts
@@ -11,7 +11,7 @@ export async function LogRequest(
 		clientIp: ctx.request.ip,
 		httpMethod: ctx.method,
 		path: ctx.path,
-		queryString: ctx.query,
+		queryString: ctx.querystring,
 		statusCode: ctx.response.status,
 		responseTime: Date.now() - timeStart,
 		contentLength: ctx.request.rawBody ? ctx.request.rawBody.length : 0,


### PR DESCRIPTION
#### Summary
- Use the string format, `ctx.querystring`, instead of the object format
  - Voltti logging specs require the field to be a string

#### Dependencies
- None

#### Testing instructions
1. Run app
1. See log output with string `queryString`, instead of object

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [ ] All Terraform changes adhere to the [infra conventions](https://voltti.atlassian.net/wiki/spaces/VOLTTI/pages/502136959/Infra-k+yt+nn+t)
- [x] The code is consistent with the existing code base
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [x] The branch has been rebased against master before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] All Terraform changes adhere to the [infra conventions](https://voltti.atlassian.net/wiki/spaces/VOLTTI/pages/502136959/Infra-k+yt+nn+t)
- [ ] The code is consistent with the existing code base
- [ ] All changes in all changed files have been reviewed
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README
- [ ] The branch has been rebased against master and force pushed if necessary before merging
```