### PR TITLE
feat/HOIV-128-display-all-nursinghome-data

### DIFF
--- a/backend/src/controllers.ts
+++ b/backend/src/controllers.ts
@@ -126,7 +126,7 @@ export async function GetNursingHome(ctx: any): Promise<any> {
 		.map((item: any) => item.replace("_hash", ""));
 
 	delete nursing_home_data.vacancy_last_updated_at;
-	delete nursing_home_data.basic_update_key;
+	// delete nursing_home_data.basic_update_key;
 
 	nursing_home_data["pic_digests"] = pic_digests;
 	nursing_home_data["pics"] = available_pics;

--- a/backend/src/controllers.ts
+++ b/backend/src/controllers.ts
@@ -125,7 +125,7 @@ export async function GetNursingHome(ctx: any): Promise<any> {
 		.map((item: any) => item.replace("_hash", ""));
 
 	delete nursing_home_data.vacancy_last_updated_at;
-	// delete nursing_home_data.basic_update_key;
+	delete nursing_home_data.basic_update_key;
 
 	nursing_home_data["pic_digests"] = pic_digests;
 	nursing_home_data["pics"] = available_pics;

--- a/backend/src/controllers.ts
+++ b/backend/src/controllers.ts
@@ -26,6 +26,7 @@ import {
 	GetDistinctCities,
 	GetNursingHomeVacancyStatus as GetNursingHomeVacancyStatusDB,
 	UpdateNursingHomeInformation as UpdateNursingHomeInformationDB,
+	UpdateNursingHomeVacancyStatus as UpdateNursingHomeVacancyStatusDB,
 	UploadNursingHomeReport as UploadNursingHomeReportDB,
 	UpdateNursingHomeImage as UpdateNursingHomeImageDB,
 	GetAllBasicUpdateKeys,
@@ -181,6 +182,16 @@ export async function DeleteNursingHome(ctx: any): Promise<number | null> {
 	return result;
 }
 
+export async function UpdateNursingHomeInformation(
+	ctx: Context,
+): Promise<boolean> {
+	const { id, key } = ctx.params;
+
+	const body: NursingHome = ctx.request.body;
+
+	return await UpdateNursingHomeInformationDB(id, key, body);
+}
+
 export async function DropAndRecreateTables(ctx: any): Promise<void | null> {
 	const adminPw = process.env.ADMIN_PASSWORD;
 	const requestPw = ctx.request.body && ctx.request.body.adminPassword;
@@ -333,25 +344,15 @@ export async function GetNursingHomeVacancyStatus(
 	return await GetNursingHomeVacancyStatusDB(id, key);
 }
 
-// export async function UpdateNursingHomeInformation(
-// 	ctx: Context,
-// ): Promise<boolean> {
-// 	const { id, key } = ctx.params;
-// 	const has_vacancy: boolean = ctx.request.body.has_vacancy;
-// 	if (typeof has_vacancy !== "boolean")
-// 		throw new Error("Invalid value in field 'has_vacancy'!");
-
-// 	return await UpdateNursingHomeInformationDB(id, key, has_vacancy);
-// }
-
-export async function UpdateNursingHomeInformation(
+export async function UpdateNursingHomeVacancyStatus(
 	ctx: Context,
 ): Promise<boolean> {
 	const { id, key } = ctx.params;
+	const has_vacancy: boolean = ctx.request.body.has_vacancy;
+	if (typeof has_vacancy !== "boolean")
+		throw new Error("Invalid value in field 'has_vacancy'!");
 
-	const body: NursingHome = ctx.request.body;
-
-	return await UpdateNursingHomeInformationDB(id, key, body);
+	return await UpdateNursingHomeVacancyStatusDB(id, key, has_vacancy);
 }
 
 export async function UpdateNursingHomeImage(ctx: Context): Promise<boolean> {

--- a/backend/src/controllers.ts
+++ b/backend/src/controllers.ts
@@ -39,7 +39,7 @@ import {
 	AddNursingHomeSurveyQuestion as AddNursingHomeSurveyQuestionDB,
 	UpdateNursingHomeSurveyQuestion as UpdateNursingHomeSurveyQuestionDB,
 	SubmitSurveyResponse as SubmitSurveyResponseDB,
-	GetSurvey as GetSurveyDB
+	GetSurvey as GetSurveyDB,
 } from "./models";
 
 import { NursingHomesFromCSV, FetchAndSaveImagesFromCSV } from "./services";
@@ -61,10 +61,8 @@ export async function AddNursingHome(ctx: any): Promise<string> {
 export async function ListNursingHomes(ctx: any): Promise<Knex.Table> {
 	const nursing_homes = await GetAllNursingHomes();
 	nursing_homes.sort((a: NursingHome, b: NursingHome) => {
-		if (a.has_vacancy && !b.has_vacancy)
-			return -1;
-		if (!a.has_vacancy && b.has_vacancy)
-			return 1;
+		if (a.has_vacancy && !b.has_vacancy) return -1;
+		if (!a.has_vacancy && b.has_vacancy) return 1;
 		return a.name.localeCompare(b.name);
 	});
 
@@ -197,7 +195,9 @@ export async function DropAndRecreateTables(ctx: any): Promise<void | null> {
 	return result1;
 }
 
-export async function DropAndRecreateSurveyAnswerTables(ctx: any): Promise<void | null> {
+export async function DropAndRecreateSurveyAnswerTables(
+	ctx: any,
+): Promise<void | null> {
 	const adminPw = process.env.ADMIN_PASSWORD;
 	const requestPw = ctx.request.body && ctx.request.body.adminPassword;
 	const isPwValid =
@@ -208,11 +208,13 @@ export async function DropAndRecreateSurveyAnswerTables(ctx: any): Promise<void 
 
 	const result1 = await DropAndRecreateNursingHomeSurveyAnswersTable();
 	const result2 = await DropAndRecreateNursingHomeSurveyScoresTable();
-	const result3= await DropAndRecreateNursingHomeSurveyTotalScoresTable();
+	const result3 = await DropAndRecreateNursingHomeSurveyTotalScoresTable();
 	return result1;
 }
 
-export async function DropAndRecreateSurveyTables(ctx: any): Promise<void | null> {
+export async function DropAndRecreateSurveyTables(
+	ctx: any,
+): Promise<void | null> {
 	const adminPw = process.env.ADMIN_PASSWORD;
 	const requestPw = ctx.request.body && ctx.request.body.adminPassword;
 	const isPwValid =
@@ -228,7 +230,9 @@ export async function DropAndRecreateSurveyTables(ctx: any): Promise<void | null
 	return result1;
 }
 
-export async function DropAndRecreateReportsTables(ctx: any): Promise<void | null> {
+export async function DropAndRecreateReportsTables(
+	ctx: any,
+): Promise<void | null> {
 	const adminPw = process.env.ADMIN_PASSWORD;
 	const requestPw = ctx.request.body && ctx.request.body.adminPassword;
 	const isPwValid =
@@ -240,7 +244,6 @@ export async function DropAndRecreateReportsTables(ctx: any): Promise<void | nul
 	const result1 = await DropAndRecreateReportsTable();
 	return result1;
 }
-
 
 export async function UploadPics(ctx: any): Promise<string | null> {
 	const adminPw = process.env.ADMIN_PASSWORD;
@@ -300,7 +303,7 @@ export async function GetPdf(ctx: any): Promise<any> {
 	if (document) {
 		ctx.response.set("Content-Type", "application/pdf");
 		ctx.response.set("Content-Length", document.length);
-		
+
 		if (ctx.params.digest)
 			ctx.response.set(
 				"Cache-Control",
@@ -330,30 +333,36 @@ export async function GetNursingHomeVacancyStatus(
 	return await GetNursingHomeVacancyStatusDB(id, key);
 }
 
+// export async function UpdateNursingHomeInformation(
+// 	ctx: Context,
+// ): Promise<boolean> {
+// 	const { id, key } = ctx.params;
+// 	const has_vacancy: boolean = ctx.request.body.has_vacancy;
+// 	if (typeof has_vacancy !== "boolean")
+// 		throw new Error("Invalid value in field 'has_vacancy'!");
+
+// 	return await UpdateNursingHomeInformationDB(id, key, has_vacancy);
+// }
+
 export async function UpdateNursingHomeInformation(
 	ctx: Context,
 ): Promise<boolean> {
 	const { id, key } = ctx.params;
-	const has_vacancy: boolean = ctx.request.body.has_vacancy;
-	if (typeof has_vacancy !== "boolean")
-		throw new Error("Invalid value in field 'has_vacancy'!");
 
-	return await UpdateNursingHomeInformationDB(id, key, has_vacancy);
+	const body: NursingHome = ctx.request.body;
+
+	return await UpdateNursingHomeInformationDB(id, key, body);
 }
 
-export async function UpdateNursingHomeImage(
-	ctx: Context,
-): Promise<boolean> {
+export async function UpdateNursingHomeImage(ctx: Context): Promise<boolean> {
 	const { id, key } = ctx.params;
 	const image: any = ctx.request.body.image;
 
 	return await UpdateNursingHomeImageDB(id, key, image);
 }
 
-export async function UploadNursingHomeReport(
-	ctx: Context,
-): Promise<boolean> {
-	const loggedIn = await GetHasLogin(ctx.get('authentication') as string);
+export async function UploadNursingHomeReport(ctx: Context): Promise<boolean> {
+	const loggedIn = await GetHasLogin(ctx.get("authentication") as string);
 
 	if (loggedIn) {
 		const { id } = ctx.params;
@@ -386,9 +395,7 @@ export async function AdminRevealSecrets(
 	};
 }
 
-export async function AdminLogin(
-	ctx: Context,
-): Promise<string | null> {
+export async function AdminLogin(ctx: Context): Promise<string | null> {
 	const adminPw = process.env.VALVONTA_PASSWORD;
 	const requestPw = ctx.request.body && ctx.request.body.adminPassword;
 	const isPwValid =
@@ -405,35 +412,29 @@ export async function AdminLogin(
 	return hash;
 }
 
-export async function CheckLogin(
-	ctx: Context,
-): Promise<string | null> {
-	const loggedIn = await GetHasLogin(ctx.get('authentication') as string);
-	if(loggedIn){
+export async function CheckLogin(ctx: Context): Promise<string | null> {
+	const loggedIn = await GetHasLogin(ctx.get("authentication") as string);
+	if (loggedIn) {
 		return "OK";
-	}else{
+	} else {
 		ctx.response.status = 401;
 		return "";
 	}
-	
 }
 
-export async function CheckSurveyKey(
-	ctx: Context,
-): Promise<string | null> {
+export async function CheckSurveyKey(ctx: Context): Promise<string | null> {
 	const valid = await GetIsValidSurveyKey(ctx.request.body.surveyKey);
-	if(valid){
+	if (valid) {
 		return "OK";
-	}else{
+	} else {
 		ctx.response.status = 401;
 		return "";
 	}
-	
 }
 
 export async function AddNursingHomeSurveyQuestion(
-	ctx: Context
-):Promise<string | null> {
+	ctx: Context,
+): Promise<string | null> {
 	const adminPw = process.env.ADMIN_PASSWORD;
 	const requestPw = ctx.request.body && ctx.request.body.adminPassword;
 	const isPwValid =
@@ -442,24 +443,25 @@ export async function AddNursingHomeSurveyQuestion(
 		requestPw === adminPw;
 	if (!isPwValid) return null;
 
-	for(const question of ctx.request.body.questions){
-		const res = await AddNursingHomeSurveyQuestionDB( 
-			question.survey_id, 
-			question.order, 
-			question.question_type, 
-			question.question_fi, 
-			question.question_sv, 
-			question.question_description_fi, 
+	for (const question of ctx.request.body.questions) {
+		const res = await AddNursingHomeSurveyQuestionDB(
+			question.survey_id,
+			question.order,
+			question.question_type,
+			question.question_fi,
+			question.question_sv,
+			question.question_description_fi,
 			question.question_description_sv,
 			question.question_icon,
-			question.active);
+			question.active,
+		);
 	}
-	return "inserted"
+	return "inserted";
 }
 
 export async function UpdateNursingHomeSurveyQuestion(
-	ctx: Context
-):Promise<string | null> {
+	ctx: Context,
+): Promise<string | null> {
 	const adminPw = process.env.ADMIN_PASSWORD;
 	const requestPw = ctx.request.body && ctx.request.body.adminPassword;
 	const isPwValid =
@@ -468,25 +470,24 @@ export async function UpdateNursingHomeSurveyQuestion(
 		requestPw === adminPw;
 	if (!isPwValid) return null;
 
-	const res = await UpdateNursingHomeSurveyQuestionDB( 
+	const res = await UpdateNursingHomeSurveyQuestionDB(
 		ctx.request.body.id,
-		ctx.request.body.survey_id, 
-		ctx.request.body.order, 
-		ctx.request.body.question_type, 
-		ctx.request.body.question_fi, 
-		ctx.request.body.question_sv, 
-		ctx.request.body.question_description_fi, 
+		ctx.request.body.survey_id,
+		ctx.request.body.order,
+		ctx.request.body.question_type,
+		ctx.request.body.question_fi,
+		ctx.request.body.question_sv,
+		ctx.request.body.question_description_fi,
 		ctx.request.body.question_description_sv,
 		ctx.request.body.question_icon,
-		ctx.request.body.active);
-	return "updated"
+		ctx.request.body.active,
+	);
+	return "updated";
 }
 
-
-
 export async function AddNursingHomeSurveyKeys(
-	ctx: Context
-):Promise<any[] | null> {
+	ctx: Context,
+): Promise<any[] | null> {
 	const adminPw = process.env.ADMIN_PASSWORD;
 	const requestPw = ctx.request.body && ctx.request.body.adminPassword;
 	const isPwValid =
@@ -495,40 +496,35 @@ export async function AddNursingHomeSurveyKeys(
 		requestPw === adminPw;
 	if (!isPwValid) return null;
 
-	const res = await AddNursingHomeSurveyKeysDB( 
-		ctx.request.body.amount
-	);
+	const res = await AddNursingHomeSurveyKeysDB(ctx.request.body.amount);
 	return res;
 }
 
 export async function SubmitSurveyResponse(
-	ctx: Context
-):Promise<string | null> {
+	ctx: Context,
+): Promise<string | null> {
 	const { id } = ctx.params;
-	const res = await SubmitSurveyResponseDB( 
-		ctx.request.body.survey, 
-		id, 
-		ctx.request.body.surveyKey
+	const res = await SubmitSurveyResponseDB(
+		ctx.request.body.survey,
+		id,
+		ctx.request.body.surveyKey,
 	);
-	return ""
+	return "";
 }
 
-export async function GetSurvey(
-	surveyId: string
-):Promise<any> {
+export async function GetSurvey(surveyId: string): Promise<any> {
 	const survey = await GetSurveyDB(surveyId);
 	return survey;
 }
 
 export async function GetSurveyWithNursingHomeResults(
 	surveyId: string,
-	nursingHomeId: string
-):Promise<any> {
+	nursingHomeId: string,
+): Promise<any> {
 	const survey = await GetSurveyDB(surveyId);
-	const results = await GetNursingHomeSurveyResults(nursingHomeId)
+	const results = await GetNursingHomeSurveyResults(nursingHomeId);
 
-
-	survey.map((question: any)=>{
+	survey.map((question: any) => {
 		question.average = 0;
 		question.answers = 0;
 		results.map((result: any) => {

--- a/backend/src/models.ts
+++ b/backend/src/models.ts
@@ -664,6 +664,22 @@ export async function DeleteNursingHome(id: string): Promise<number> {
 	return result;
 }
 
+export async function UpdateNursingHomeInformation(
+	id: string,
+	basicUpdateKey: string,
+	body: NursingHome,
+): Promise<boolean> {
+	let count = await knex("NursingHomes")
+		.where({ id, basic_update_key: basicUpdateKey })
+		.update({
+			...body,
+		});
+
+	if (count !== 1) return false;
+
+	return true;
+}
+
 export async function DeleteNursingHomePics(id: string): Promise<number> {
 	const result = await knex
 		.table("NursingHomePictures")
@@ -910,36 +926,17 @@ export async function UpdateNursingHomeImage(
 	return true;
 }
 
-// export async function UpdateNursingHomeInformation(
-// 	id: string,
-// 	basicUdpateKey: string,
-// 	status: boolean,
-// ): Promise<boolean> {
-// 	const now = new Date().toISOString();
-
-// 	let count = await knex("NursingHomes")
-// 		.where({ id, basic_update_key: basicUdpateKey })
-// 		.update({
-// 			has_vacancy: status,
-// 			vacancy_last_updated_at: now,
-// 		});
-
-// 	if (count !== 1) return false;
-
-// 	return true;
-// }
-
-export async function UpdateNursingHomeInformation(
+export async function UpdateNursingHomeVacancyStatus(
 	id: string,
-	basicUpdateKey: string,
-	body: NursingHome,
+	basicUdpateKey: string,
+	status: boolean,
 ): Promise<boolean> {
 	const now = new Date().toISOString();
 
 	let count = await knex("NursingHomes")
-		.where({ id, basic_update_key: basicUpdateKey })
+		.where({ id, basic_update_key: basicUdpateKey })
 		.update({
-			...body,
+			has_vacancy: status,
 			vacancy_last_updated_at: now,
 		});
 

--- a/backend/src/models.ts
+++ b/backend/src/models.ts
@@ -9,7 +9,13 @@ import {
 	postal_code_to_district,
 } from "./nursinghome-typings";
 import config from "./config";
-import { createBasicUpdateKey, hashWithSalt, NursingHomesFromCSV, validNumericSurveyScore, createSurveyKey } from "./services";
+import {
+	createBasicUpdateKey,
+	hashWithSalt,
+	NursingHomesFromCSV,
+	validNumericSurveyScore,
+	createSurveyKey,
+} from "./services";
 import sharp from "sharp";
 
 const options: Knex.Config = {
@@ -45,38 +51,42 @@ knex.schema.hasTable("NursingHomeReports").then(async (exists: boolean) => {
 	await CreateNursingHomeReportsTable();
 });
 
-knex.schema.hasTable("NursingHomeSurveyQuestions").then(async (exists: boolean) => {
-	if (exists) return;
+knex.schema
+	.hasTable("NursingHomeSurveyQuestions")
+	.then(async (exists: boolean) => {
+		if (exists) return;
 
-	await CreateNursingHomeSurveyQuestionsTable();
-});
+		await CreateNursingHomeSurveyQuestionsTable();
+	});
 
-knex.schema.hasTable("NursingHomeSurveyAnswers").then(async (exists: boolean) => {
-	if (exists) return;
+knex.schema
+	.hasTable("NursingHomeSurveyAnswers")
+	.then(async (exists: boolean) => {
+		if (exists) return;
 
-	await CreateNursingHomeSurveyAnswersTable();
+		await CreateNursingHomeSurveyAnswersTable();
+	});
 
-});
+knex.schema
+	.hasTable("NursingHomeSurveyScores")
+	.then(async (exists: boolean) => {
+		if (exists) return;
 
-knex.schema.hasTable("NursingHomeSurveyScores").then(async (exists: boolean) => {
-	if (exists) return;
+		await CreateNursingHomeSurveyScoresTable();
+	});
 
-	await CreateNursingHomeSurveyScoresTable();
+knex.schema
+	.hasTable("NursingHomeSurveyTotalScores")
+	.then(async (exists: boolean) => {
+		if (exists) return;
 
-});
-
-knex.schema.hasTable("NursingHomeSurveyTotalScores").then(async (exists: boolean) => {
-	if (exists) return;
-
-	await CreateNursingHomeSurveyTotalScoresTable();
-
-});
+		await CreateNursingHomeSurveyTotalScoresTable();
+	});
 
 knex.schema.hasTable("NursingHomeSurveyKeys").then(async (exists: boolean) => {
 	if (exists) return;
 
 	await CreateNursingHomeSurveyKeysTable();
-
 });
 
 knex.schema.hasTable("AdminSessions").then(async (exists: boolean) => {
@@ -92,14 +102,14 @@ function checksum(str: string | BinaryLike): string {
 		.digest("hex");
 }
 
-async function resizeImage (image:  Buffer){
+async function resizeImage(image: Buffer) {
 	return await sharp(image)
-			.resize(900, 900, {
-				fit: sharp.fit.inside,
-				withoutEnlargement: true
-			  })
-			.jpeg({quality: 90})
-			.toBuffer();
+		.resize(900, 900, {
+			fit: sharp.fit.inside,
+			withoutEnlargement: true,
+		})
+		.jpeg({ quality: 90 })
+		.toBuffer();
 }
 
 async function CreateNursingHomePicturesTable(): Promise<void> {
@@ -119,88 +129,82 @@ async function CreateNursingHomePicturesTable(): Promise<void> {
 
 async function CreateNursingHomeReportsTable(): Promise<void> {
 	await knex.schema.createTable("NursingHomeReports", (table: any) => {
-		
 		table.string("nursinghome_id");
-		table.string("date")
-		table.string("status")
+		table.string("date");
+		table.string("status");
 		table.binary("report_file");
-		
 	});
 
 	const nursingHomes = await GetAllNursingHomes();
-	for(const nursingHome of nursingHomes){
-		if(nursingHome.city != "Espoo" && nursingHome.city != "Esbo"){
-			await knex
-				.table("NursingHomeReports")
-				.insert({
-					nursinghome_id: nursingHome.id,
-					status: "no-info"
-				});
+	for (const nursingHome of nursingHomes) {
+		if (nursingHome.city != "Espoo" && nursingHome.city != "Esbo") {
+			await knex.table("NursingHomeReports").insert({
+				nursinghome_id: nursingHome.id,
+				status: "no-info",
+			});
 		}
 	}
 }
 
 async function CreateAdminSessionsTable(): Promise<void> {
 	await knex.schema.createTable("AdminSessions", (table: any) => {
-		
 		table.string("hash");
 		table.string("date");
-
 	});
 }
 
 async function CreateNursingHomeSurveyQuestionsTable(): Promise<void> {
-	await knex.schema.createTable("NursingHomeSurveyQuestions", (table: any) => {
-		
-		table.increments("id");
-		table.string("survey_id");
-		table.integer("order");
-		table.boolean("active");
-		table.string("question_type");
-		table.string("question_fi");
-		table.string("question_sv");
-		table.string("question_description_fi");
-		table.string("question_description_sv");
-		table.string("question_icon");
-
-	});
+	await knex.schema.createTable(
+		"NursingHomeSurveyQuestions",
+		(table: any) => {
+			table.increments("id");
+			table.string("survey_id");
+			table.integer("order");
+			table.boolean("active");
+			table.string("question_type");
+			table.string("question_fi");
+			table.string("question_sv");
+			table.string("question_description_fi");
+			table.string("question_description_sv");
+			table.string("question_icon");
+		},
+	);
 }
 
 async function CreateNursingHomeSurveyAnswersTable(): Promise<void> {
 	await knex.schema.createTable("NursingHomeSurveyAnswers", (table: any) => {
-		
 		table.increments("id");
 		table.integer("question_id");
 		table.string("nursinghome_id");
 		table.string("answer");
 		table.string("key");
-		table.boolean("replaced")
-
+		table.boolean("replaced");
 	});
 }
 
 async function CreateNursingHomeSurveyScoresTable(): Promise<void> {
 	await knex.schema.createTable("NursingHomeSurveyScores", (table: any) => {
 		table.integer("question_id");
-		table.string("nursinghome_id");		
+		table.string("nursinghome_id");
 		table.integer("answers");
 		table.float("average");
-
 	});
 }
 
-
 async function CreateNursingHomeSurveyTotalScoresTable(): Promise<void> {
-	await knex.schema.createTable("NursingHomeSurveyTotalScores", (table: any) => {
-		table.string("nursinghome_id");	
-		table.float("average");
-		table.integer("answers");
-	});
+	await knex.schema.createTable(
+		"NursingHomeSurveyTotalScores",
+		(table: any) => {
+			table.string("nursinghome_id");
+			table.float("average");
+			table.integer("answers");
+		},
+	);
 }
 
 async function CreateNursingHomeSurveyKeysTable(): Promise<void> {
 	await knex.schema.createTable("NursingHomeSurveyKeys", (table: any) => {
-		table.string("key");	
+		table.string("key");
 		table.string("status");
 	});
 }
@@ -272,28 +276,36 @@ export async function DropAndRecreateNursingHomePicturesTable(): Promise<void> {
 	return result;
 }
 
-export async function DropAndRecreateNursingHomeSurveyAnswersTable(): Promise<void> {
+export async function DropAndRecreateNursingHomeSurveyAnswersTable(): Promise<
+	void
+> {
 	const exists = await knex.schema.hasTable("NursingHomeSurveyAnswers");
 	if (exists) await knex.schema.dropTable("NursingHomeSurveyAnswers");
 	const result = await CreateNursingHomeSurveyAnswersTable();
 	return result;
 }
 
-export async function DropAndRecreateNursingHomeSurveyScoresTable(): Promise<void> {
+export async function DropAndRecreateNursingHomeSurveyScoresTable(): Promise<
+	void
+> {
 	const exists = await knex.schema.hasTable("NursingHomeSurveyScores");
 	if (exists) await knex.schema.dropTable("NursingHomeSurveyScores");
 	const result = await CreateNursingHomeSurveyScoresTable();
 	return result;
 }
 
-export async function DropAndRecreateNursingHomeSurveyTotalScoresTable(): Promise<void> {
+export async function DropAndRecreateNursingHomeSurveyTotalScoresTable(): Promise<
+	void
+> {
 	const exists = await knex.schema.hasTable("NursingHomeSurveyTotalScores");
 	if (exists) await knex.schema.dropTable("NursingHomeSurveyTotalScores");
 	const result = await CreateNursingHomeSurveyTotalScoresTable();
 	return result;
 }
 
-export async function DropAndRecreateNursingHomeSurveyQuestionsTable(): Promise<void> {
+export async function DropAndRecreateNursingHomeSurveyQuestionsTable(): Promise<
+	void
+> {
 	const exists = await knex.schema.hasTable("NursingHomeSurveyQuestions");
 	if (exists) await knex.schema.dropTable("NursingHomeSurveyQuestions");
 	const result = await CreateNursingHomeSurveyQuestionsTable();
@@ -320,8 +332,8 @@ export async function InsertNursingHomeToDB(
 	const geoloc = JSON.parse(
 		await rp(
 			"https://api.mapbox.com/geocoding/v5/mapbox.places/" +
-			geo_query +
-			".json?access_token=pk.eyJ1IjoidHphZXJ1LXJlYWt0b3IiLCJhIjoiY2sxZzIxazd0MHg0eDNubzV5Mm41MnJzdCJ9.vPaqUY1S8qHgfzwHUuYUcg",
+				geo_query +
+				".json?access_token=pk.eyJ1IjoidHphZXJ1LXJlYWt0b3IiLCJhIjoiY2sxZzIxazd0MHg0eDNubzV5Mm41MnJzdCJ9.vPaqUY1S8qHgfzwHUuYUcg",
 		),
 	);
 
@@ -355,13 +367,11 @@ export async function InsertNursingHomeToDB(
 			district: postal_code_to_district[nursingHome.postal_code],
 			basic_update_key: basicUpdateKey,
 		});
-		if(nursingHome.city != "Espoo" && nursingHome.city != "Esbo"){
-			await knex
-				.table("NursingHomeReports")
-				.insert({
-					nursinghome_id: uuid,
-					status: "no-info"
-				});
+		if (nursingHome.city != "Espoo" && nursingHome.city != "Esbo") {
+			await knex.table("NursingHomeReports").insert({
+				nursinghome_id: uuid,
+				status: "no-info",
+			});
 		}
 
 		return uuid;
@@ -377,7 +387,7 @@ export async function AddNursingHomeSurveyQuestion(
 	questionDescriptionFI: string,
 	questionDescriptionSV: string,
 	questionIcon: string,
-	active: boolean
+	active: boolean,
 ): Promise<void> {
 	await knex("NursingHomeSurveyQuestions").insert({
 		survey_id: surveyId,
@@ -388,7 +398,7 @@ export async function AddNursingHomeSurveyQuestion(
 		question_description_fi: questionDescriptionFI,
 		question_description_sv: questionDescriptionSV,
 		question_icon: questionIcon,
-		active: active
+		active: active,
 	});
 }
 
@@ -402,30 +412,28 @@ export async function UpdateNursingHomeSurveyQuestion(
 	questionDescriptionFI: string,
 	questionDescriptionSV: string,
 	questionIcon: string,
-	active: boolean
+	active: boolean,
 ): Promise<void> {
 	await knex("NursingHomeSurveyQuestions")
-	.where({id: id})
-	.update({
-		survey_id: surveyId,
-		order: order,
-		question_type: questionType,
-		question_fi: questionFI,
-		question_sv: questionSV,
-		question_description_fi: questionDescriptionFI,
-		question_description_sv: questionDescriptionSV,
-		question_icon: questionIcon,
-		active: active
-	});
+		.where({ id: id })
+		.update({
+			survey_id: surveyId,
+			order: order,
+			question_type: questionType,
+			question_fi: questionFI,
+			question_sv: questionSV,
+			question_description_fi: questionDescriptionFI,
+			question_description_sv: questionDescriptionSV,
+			question_icon: questionIcon,
+			active: active,
+		});
 }
 
-export async function AddNursingHomeSurveyKeys(
-	amount: number,
-): Promise<any[]> {
+export async function AddNursingHomeSurveyKeys(amount: number): Promise<any[]> {
 	let keys: any[] = [];
-	for(let i = 0; i < amount; i++){
+	for (let i = 0; i < amount; i++) {
 		const key = createSurveyKey(8);
-		keys.push({key: key})
+		keys.push({ key: key });
 	}
 	await knex("NursingHomeSurveyKeys").insert(keys);
 
@@ -433,28 +441,30 @@ export async function AddNursingHomeSurveyKeys(
 }
 
 export async function GetSurvey(surveyId: string): Promise<any[]> {
-	const result = await knex.table("NursingHomeSurveyQuestions")
+	const result = await knex
+		.table("NursingHomeSurveyQuestions")
 		.select()
 		.where({ survey_id: surveyId })
 		.orderBy("order");
 	return result;
 }
 
-export async function GetNursingHomeSurveyResults(nursingHomeId:string ): Promise<any[]> {
-	const results = await knex.table("NursingHomeSurveyScores")
+export async function GetNursingHomeSurveyResults(
+	nursingHomeId: string,
+): Promise<any[]> {
+	const results = await knex
+		.table("NursingHomeSurveyScores")
 		.select()
 		.where({ nursinghome_id: nursingHomeId });
 
-	
 	return results;
 }
 
 export async function SubmitSurveyResponse(
 	survey: any,
 	nursinghomeId: string,
-	key: string
+	key: string,
 ): Promise<void> {
-
 	let totalScore = 0;
 	let numQuestions = 0;
 	let updateTotal = 1; //use number instead of boolean for multiplication
@@ -464,50 +474,49 @@ export async function SubmitSurveyResponse(
 	const validKey = await GetIsValidSurveyKey(key);
 
 	if (validKey) {
-
 		//remove possible old answers with same key code
 		let oldAnswersNursingHomeId = "";
-		
+
 		const existingAnswer = await knex
 			.table("NursingHomeSurveyAnswers")
 			.select()
 			.where({
 				key: key,
 				nursinghome_id: nursinghomeId,
-				replaced: false
+				replaced: false,
 			});
-		
-		if(existingAnswer.length != 0){
 
-			updateTotal = 0 //do not increment total count to NursingHomeSurveyTotalScores
+		if (existingAnswer.length != 0) {
+			updateTotal = 0; //do not increment total count to NursingHomeSurveyTotalScores
 
 			oldAnswersNursingHomeId = existingAnswer[0].nursinghome_id;
 
 			for (const answer of existingAnswer) {
-
 				const currentScores = await knex
 					.table("NursingHomeSurveyScores")
 					.select()
 					.where({
-						question_id: answer.question_id, 
-						nursinghome_id: oldAnswersNursingHomeId
+						question_id: answer.question_id,
+						nursinghome_id: oldAnswersNursingHomeId,
 					});
-				
-				let newAvg = currentScores[0].average * currentScores[0].answers - answer.answer; //remove old answer from average
-				if (newAvg > 0) newAvg = newAvg / (currentScores[0].answers - 1);
-				
+
+				let newAvg =
+					currentScores[0].average * currentScores[0].answers -
+					answer.answer; //remove old answer from average
+				if (newAvg > 0)
+					newAvg = newAvg / (currentScores[0].answers - 1);
+
 				await knex
 					.table("NursingHomeSurveyScores")
 					.where({
-						question_id: answer.question_id, 
-						nursinghome_id: oldAnswersNursingHomeId
+						question_id: answer.question_id,
+						nursinghome_id: oldAnswersNursingHomeId,
 					})
 					.update({
 						answers: currentScores[0].answers - 1,
-						average: newAvg
+						average: newAvg,
 					});
 			}
-
 		}
 
 		await knex
@@ -515,10 +524,10 @@ export async function SubmitSurveyResponse(
 			.where({
 				key: key,
 				nursinghome_id: nursinghomeId,
-				replaced: false
+				replaced: false,
 			})
 			.update({
-				replaced: true
+				replaced: true,
 			});
 
 		//store new values
@@ -527,103 +536,94 @@ export async function SubmitSurveyResponse(
 				.table("NursingHomeSurveyScores")
 				.select()
 				.where({
-					question_id: question.id, 
-					nursinghome_id: nursinghomeId
+					question_id: question.id,
+					nursinghome_id: nursinghomeId,
 				});
 
-			if(currentScores.length === 0 && validNumericSurveyScore(question.value)){
-				await knex
-					.table("NursingHomeSurveyScores")
-					.insert({
-						question_id: question.id, 
-						nursinghome_id: nursinghomeId,
-						answers: 1,
-						average: question.value
-					});
-				
-				await knex
-					.table("NursingHomeSurveyAnswers")
-					.insert({
-						question_id: question.id, 
-						nursinghome_id: nursinghomeId,
-						answer: question.value,
-						key: key,
-						replaced: false	
-					});
+			if (
+				currentScores.length === 0 &&
+				validNumericSurveyScore(question.value)
+			) {
+				await knex.table("NursingHomeSurveyScores").insert({
+					question_id: question.id,
+					nursinghome_id: nursinghomeId,
+					answers: 1,
+					average: question.value,
+				});
+
+				await knex.table("NursingHomeSurveyAnswers").insert({
+					question_id: question.id,
+					nursinghome_id: nursinghomeId,
+					answer: question.value,
+					key: key,
+					replaced: false,
+				});
 
 				totalScore += question.value;
 				numQuestions += 1;
-				
-			}else{
-
-				if (validNumericSurveyScore(question.value)){
+			} else {
+				if (validNumericSurveyScore(question.value)) {
 					const newSum = currentScores[0].answers + 1;
-					const newAvg = (currentScores[0].average * currentScores[0].answers + question.value) / newSum;
+					const newAvg =
+						(currentScores[0].average * currentScores[0].answers +
+							question.value) /
+						newSum;
 
 					await knex
 						.table("NursingHomeSurveyScores")
 						.where({
-							question_id: question.id, 
-							nursinghome_id: nursinghomeId
+							question_id: question.id,
+							nursinghome_id: nursinghomeId,
 						})
 						.update({
 							answers: newSum,
-							average: newAvg
+							average: newAvg,
 						});
 
-					await knex
-						.table("NursingHomeSurveyAnswers")
-						.insert({
-							question_id: question.id, 
-							nursinghome_id: nursinghomeId,
-							answer: question.value,
-							key: key,
-							replaced: false
-							
-						});
-
+					await knex.table("NursingHomeSurveyAnswers").insert({
+						question_id: question.id,
+						nursinghome_id: nursinghomeId,
+						answer: question.value,
+						key: key,
+						replaced: false,
+					});
 
 					totalScore += newAvg;
 					numQuestions += 1;
-
-				}else if (currentScores.length > 0){
+				} else if (currentScores.length > 0) {
 					totalScore += currentScores[0].average;
 					numQuestions += 1;
 				}
 			}
-
 		}
 
 		const currentTotal = await knex
 			.table("NursingHomeSurveyTotalScores")
 			.select()
 			.where({
-				nursinghome_id: nursinghomeId
+				nursinghome_id: nursinghomeId,
 			});
-		
-		if(numQuestions > 0){
-			if(currentTotal.length === 0){
-				await knex
-					.table("NursingHomeSurveyTotalScores")
-					.insert({
-						nursinghome_id: nursinghomeId,
-						average: (totalScore / numQuestions),
-						answers: 1
-					});
-			}else{
+
+		if (numQuestions > 0) {
+			if (currentTotal.length === 0) {
+				await knex.table("NursingHomeSurveyTotalScores").insert({
+					nursinghome_id: nursinghomeId,
+					average: totalScore / numQuestions,
+					answers: 1,
+				});
+			} else {
 				await knex
 					.table("NursingHomeSurveyTotalScores")
 					.where({
-						nursinghome_id: nursinghomeId
+						nursinghome_id: nursinghomeId,
 					})
 					.update({
-						average: (totalScore / numQuestions),
-						answers: currentTotal[0].answers + (1 * updateTotal)
+						average: totalScore / numQuestions,
+						answers: currentTotal[0].answers + 1 * updateTotal,
 					});
 			}
 		}
 	}
-
 }
 
 export async function GetNursingHomeIDFromName(name: string): Promise<any[]> {
@@ -770,9 +770,7 @@ export async function GetAllPicDigests(): Promise<any[]> {
 	return await knex.select(columns).table("NursingHomePictures");
 }
 
-export async function GetPdfData(
-	nursinghome_id: string,
-): Promise<any[]> {
+export async function GetPdfData(nursinghome_id: string): Promise<any[]> {
 	return await knex
 		.select("report_file")
 		.table("NursingHomeReports")
@@ -804,47 +802,44 @@ export async function GetAllNursingHomeStatus(): Promise<any[]> {
 }
 
 export async function GetAllNursingHomeRatings(): Promise<any[]> {
-	return await knex
-		.select()
-		.table("NursingHomeSurveyTotalScores");
+	return await knex.select().table("NursingHomeSurveyTotalScores");
 }
-
 
 export async function GetDistinctCities(): Promise<any[]> {
 	return await knex("NursingHomes").distinct("city");
 }
 
-export async function UploadNursingHomeReport(  //USE ONLY WHEN AUTHENTICATED
+export async function UploadNursingHomeReport( //USE ONLY WHEN AUTHENTICATED
 	id: string,
 	status: string,
 	date: string,
 	file: any,
 ): Promise<boolean> {
-
 	const nursingHomeValid = await knex
-			.select()
-			.table("NursingHomes")
-			.where({ id });
+		.select()
+		.table("NursingHomes")
+		.where({ id });
 
-	if(nursingHomeValid.length === 0) return false;
+	if (nursingHomeValid.length === 0) return false;
 
 	const nursingHomeExsists = await knex
-			.select()
-			.table("NursingHomeReports")
-			.where({ nursinghome_id: id });
+		.select()
+		.table("NursingHomeReports")
+		.where({ nursinghome_id: id });
 
-	if(nursingHomeExsists.length < 1) {
-		await knex("NursingHomeReports").insert({nursinghome_id: id});
+	if (nursingHomeExsists.length < 1) {
+		await knex("NursingHomeReports").insert({ nursinghome_id: id });
 	}
 
-	let fileData = file != "" ? Buffer.from(file.split(",")[1], 'base64') : null;
+	let fileData =
+		file != "" ? Buffer.from(file.split(",")[1], "base64") : null;
 
 	let count = await knex("NursingHomeReports")
-		.where({ nursinghome_id: id})
+		.where({ nursinghome_id: id })
 		.update({
 			status: status,
 			date: date,
-			report_file: fileData
+			report_file: fileData,
 		});
 
 	if (count == 0) return false;
@@ -875,60 +870,79 @@ export async function UpdateNursingHomeImage(
 	basicUdpateKey: string,
 	image: any,
 ): Promise<boolean> {
-
-	if (image) { 
+	if (image) {
 		const nursingHomeExsists = await knex
 			.select()
 			.table("NursingHomePictures")
 			.where({ nursinghome_id: id });
 
-		if(nursingHomeExsists.length < 1) {
-			await knex("NursingHomePictures").insert({nursinghome_id: id});
+		if (nursingHomeExsists.length < 1) {
+			await knex("NursingHomePictures").insert({ nursinghome_id: id });
 		}
 
-		if (image.value || image.remove) { 
-	
-			let imageData = image.remove ? new Buffer("", 'base64') : new Buffer(image.value.split(",")[1], 'base64');
-	
+		if (image.value || image.remove) {
+			let imageData = image.remove
+				? new Buffer("", "base64")
+				: new Buffer(image.value.split(",")[1], "base64");
+
 			if (!image.remove) imageData = await resizeImage(imageData);
-		
+
 			await knex("NursingHomePictures")
 				.where({ nursinghome_id: id })
 				.update({
 					[image.name]: image.remove ? null : imageData,
-					[image.name + "_hash"]: image.remove ? null : checksum(imageData)
-			});
-		}
-		
-		if(image.name != "owner_logo") {
-			//only update the text if no image was given
-			await knex("NursingHomePictures")
-			.where({ nursinghome_id: id })
-			.update({
-				[image.name + "_caption"]: image.text
-			});
+					[image.name + "_hash"]: image.remove
+						? null
+						: checksum(imageData),
+				});
 		}
 
+		if (image.name != "owner_logo") {
+			//only update the text if no image was given
+			await knex("NursingHomePictures")
+				.where({ nursinghome_id: id })
+				.update({
+					[image.name + "_caption"]: image.text,
+				});
+		}
 	}
 
 	return true;
 }
 
+// export async function UpdateNursingHomeInformation(
+// 	id: string,
+// 	basicUdpateKey: string,
+// 	status: boolean,
+// ): Promise<boolean> {
+// 	const now = new Date().toISOString();
+
+// 	let count = await knex("NursingHomes")
+// 		.where({ id, basic_update_key: basicUdpateKey })
+// 		.update({
+// 			has_vacancy: status,
+// 			vacancy_last_updated_at: now,
+// 		});
+
+// 	if (count !== 1) return false;
+
+// 	return true;
+// }
 
 export async function UpdateNursingHomeInformation(
 	id: string,
-	basicUdpateKey: string,
-	status: boolean,
+	basicUpdateKey: string,
+	body: NursingHome,
 ): Promise<boolean> {
 	const now = new Date().toISOString();
 
 	let count = await knex("NursingHomes")
-		.where({ id, basic_update_key: basicUdpateKey })
+		.where({ id, basic_update_key: basicUpdateKey })
 		.update({
-			has_vacancy: status,
+			...body,
 			vacancy_last_updated_at: now,
 		});
-	
+
 	if (count !== 1) return false;
 
 	return true;
@@ -954,41 +968,38 @@ export async function GetAllBasicUpdateKeys(): Promise<BasicUpdateKeyEntry[]> {
 }
 
 export async function GetLoginCookieHash(): Promise<string> {
-	const hash = hashWithSalt(uuidv4(), process.env.VALVONTA_PASSWORD as string);
+	const hash = hashWithSalt(
+		uuidv4(),
+		process.env.VALVONTA_PASSWORD as string,
+	);
 	const timestamp = Date.now();
-	await knex("AdminSessions").insert({hash: hash, date: timestamp});
+	await knex("AdminSessions").insert({ hash: hash, date: timestamp });
 	return hash;
 }
 
 export async function GetHasLogin(cookie: string): Promise<boolean> {
-	const sessions = await knex("AdminSessions").select("date").where({hash: cookie});
-	if(sessions.length == 1){
+	const sessions = await knex("AdminSessions")
+		.select("date")
+		.where({ hash: cookie });
+	if (sessions.length == 1) {
 		return true;
-	}else{
+	} else {
 		return false;
 	}
 }
 
 export async function GetIsValidSurveyKey(key: string): Promise<boolean> {
-	const keys = await knex("NursingHomeSurveyKeys").select().where({key: key});
-	if(keys.length == 1){
+	const keys = await knex("NursingHomeSurveyKeys")
+		.select()
+		.where({ key: key });
+	if (keys.length == 1) {
 		return true;
-	}else{
+	} else {
 		return false;
 	}
 }
 
-
-
-
-
-
-
-
-
-
 //DUMMY DATA FOR TESTING
-
 
 export async function addDummyNursingHome(): Promise<string> {
 	const nursinghome: NursingHome = {
@@ -998,10 +1009,11 @@ export async function addDummyNursingHome(): Promise<string> {
 		city: "Espoo",
 		address: "Tie 1",
 		language: "Suomi",
-		tour_info: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque luctus egestas efficitur. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem."
+		tour_info:
+			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque luctus egestas efficitur. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem.",
 	};
 
-	await InsertNursingHomeToDB(nursinghome)
+	await InsertNursingHomeToDB(nursinghome);
 
 	const nursinghome2: NursingHome = {
 		name: "Testi 2 Nursinghome with a very long name",
@@ -1010,10 +1022,10 @@ export async function addDummyNursingHome(): Promise<string> {
 		city: "Espoo",
 		address: "Suotie 1",
 		language: "Ruotsi",
-		tour_info: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque luctus egestas efficitur. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem."
-
+		tour_info:
+			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque luctus egestas efficitur. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem.",
 	};
-	await InsertNursingHomeToDB(nursinghome2)
+	await InsertNursingHomeToDB(nursinghome2);
 
 	const nursinghome3: NursingHome = {
 		name: "Testi 3",
@@ -1022,10 +1034,11 @@ export async function addDummyNursingHome(): Promise<string> {
 		city: "Kerava",
 		address: "Ojatie 1",
 		language: "Suomi",
-		tour_info: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque luctus egestas efficitur. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem."
+		tour_info:
+			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque luctus egestas efficitur. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem.",
 	};
 
-	await InsertNursingHomeToDB(nursinghome3)
+	await InsertNursingHomeToDB(nursinghome3);
 
 	const nursinghome4: NursingHome = {
 		name: "Testi 4",
@@ -1034,10 +1047,11 @@ export async function addDummyNursingHome(): Promise<string> {
 		city: "Helsinki",
 		address: "Jokitie 1",
 		language: "Suomi",
-		tour_info: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque luctus egestas efficitur. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem."
+		tour_info:
+			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque luctus egestas efficitur. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem.",
 	};
 
-	await InsertNursingHomeToDB(nursinghome4)
+	await InsertNursingHomeToDB(nursinghome4);
 
 	const nursinghome5: NursingHome = {
 		name: "Testi 5",
@@ -1046,8 +1060,8 @@ export async function addDummyNursingHome(): Promise<string> {
 		city: "Vantaa",
 		address: "Tie 1",
 		language: "Suomi",
-		tour_info: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque luctus egestas efficitur. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem."
-
+		tour_info:
+			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque luctus egestas efficitur. Nunc iaculis, lorem id iaculis suscipit, nisl mauris elementum sem.",
 	};
 
 	return await InsertNursingHomeToDB(nursinghome5);

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -33,7 +33,7 @@ import {
 	GetSurvey,
 	AdminLogin,
 	CheckLogin,
-	CheckSurveyKey
+	CheckSurveyKey,
 } from "./controllers";
 import config from "./config";
 
@@ -118,7 +118,17 @@ router.get("/api/nursing-homes/:id/vacancy-status/:key", async ctx => {
 	}
 });
 
-router.post("/api/nursing-homes/:id/vacancy-status/:key", async ctx => {
+// router.post("/api/nursing-homes/:id/vacancy-status/:key", async ctx => {
+// 	const success = await UpdateNursingHomeInformation(ctx);
+// 	if (!success) {
+// 		ctx.response.status = 403;
+// 		ctx.body = { error: "Forbidden: invalid ID or key" };
+// 	} else {
+// 		ctx.body = { success };
+// 	}
+// });
+
+router.post("/api/nursing-homes/:id/update/:key", async ctx => {
 	const success = await UpdateNursingHomeInformation(ctx);
 	if (!success) {
 		ctx.response.status = 403;
@@ -129,7 +139,7 @@ router.post("/api/nursing-homes/:id/vacancy-status/:key", async ctx => {
 });
 
 router.get("/api/nursing-homes/:id/raportti/:key", async ctx => {
-  ctx.body = await GetPdf(ctx);
+	ctx.body = await GetPdf(ctx);
 });
 
 router.post("/api/nursing-homes/:id/update-image/:key", async ctx => {
@@ -204,17 +214,22 @@ router.get("/api/survey/:key", async ctx => {
 });
 
 router.post("/api/survey/:id/responses", async ctx => {
-	const res = ""; await SubmitSurveyResponse(ctx);
+	const res = "";
+	await SubmitSurveyResponse(ctx);
 	ctx.body = res;
 });
 
 router.post("/api/survey/:id/answers/:key", async ctx => {
-	const res = ""; await AddNursingHomeSurveyQuestion(ctx);
+	const res = "";
+	await AddNursingHomeSurveyQuestion(ctx);
 	ctx.body = res;
 });
 
 router.get("/api/survey/:id/results/:survey", async ctx => {
-	const res = await GetSurveyWithNursingHomeResults(ctx.params.survey, ctx.params.id);
+	const res = await GetSurveyWithNursingHomeResults(
+		ctx.params.survey,
+		ctx.params.id,
+	);
 	ctx.body = res;
 });
 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -34,6 +34,7 @@ import {
 	AdminLogin,
 	CheckLogin,
 	CheckSurveyKey,
+	UpdateNursingHomeVacancyStatus,
 } from "./controllers";
 import config from "./config";
 
@@ -96,6 +97,16 @@ router.del("/api/nursing-homes/:id", async ctx => {
 	ctx.body = await DeleteNursingHome(ctx);
 });
 
+router.post("/api/nursing-homes/:id/update/:key", async ctx => {
+	const success = await UpdateNursingHomeInformation(ctx);
+	if (!success) {
+		ctx.response.status = 403;
+		ctx.body = { error: "Forbidden: invalid ID or key" };
+	} else {
+		ctx.body = { success };
+	}
+});
+
 router.get("/api/nursing-homes/:id/pics", async ctx => {
 	ctx.body = await GetPicsAndDescriptions(ctx);
 });
@@ -118,18 +129,8 @@ router.get("/api/nursing-homes/:id/vacancy-status/:key", async ctx => {
 	}
 });
 
-// router.post("/api/nursing-homes/:id/vacancy-status/:key", async ctx => {
-// 	const success = await UpdateNursingHomeInformation(ctx);
-// 	if (!success) {
-// 		ctx.response.status = 403;
-// 		ctx.body = { error: "Forbidden: invalid ID or key" };
-// 	} else {
-// 		ctx.body = { success };
-// 	}
-// });
-
-router.post("/api/nursing-homes/:id/update/:key", async ctx => {
-	const success = await UpdateNursingHomeInformation(ctx);
+router.post("/api/nursing-homes/:id/vacancy-status/:key", async ctx => {
+	const success = await UpdateNursingHomeVacancyStatus(ctx);
 	if (!success) {
 		ctx.response.status = 403;
 		ctx.body = { error: "Forbidden: invalid ID or key" };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "2.3.3",
 		"@typescript-eslint/parser": "2.3.3",
-		"chromedriver": "^87.0.7",
+		"chromedriver": "87.0.7",
 		"eslint": "6.5.1",
 		"eslint-config-prettier": "6.4.0",
 		"eslint-plugin-prettier": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "frontend", 
+	"name": "frontend",
 	"version": "0.1.0",
 	"private": true,
 	"dependencies": {
@@ -53,7 +53,7 @@
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "2.3.3",
 		"@typescript-eslint/parser": "2.3.3",
-		"chromedriver": "87.0.7",
+		"chromedriver": "^87.0.7",
 		"eslint": "6.5.1",
 		"eslint-config-prettier": "6.4.0",
 		"eslint-plugin-prettier": "3.1.1",

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -19,6 +19,7 @@ import ScrollToTop from "./ScrollToTop";
 import PageAccessibility from "./PageAccessibility";
 import Title from "./Title";
 import PageUpdate from "./PageUpdate";
+import PageUpdateImages from "./PageUpdateImages";
 import PageUploadReport from "./PageUploadReport";
 import PageReportsAdmin from "./PageReportsAdmin";
 import PageCancel from "./PageCancel";
@@ -64,6 +65,11 @@ const App: React.FC = () => {
 								exact
 								path="/hoivakodit/:id/paivita/:key"
 								component={PageUpdate}
+							/>
+							<Route
+								exact
+								path="/hoivakodit/:id/paivita/:key/kuvat"
+								component={PageUpdateImages}
 							/>
 							<Route
 								exact

--- a/frontend/src/components/Checkbox.tsx
+++ b/frontend/src/components/Checkbox.tsx
@@ -6,12 +6,14 @@ interface Props {
 	id: string;
 	isChecked: boolean;
 	onChange: (checked: boolean) => void;
+	onBlur?: () => void;
 }
 
 const Checkbox: React.FunctionComponent<Props> = ({
 	name,
 	id,
 	onChange,
+	onBlur,
 	children,
 	isChecked,
 }) => {
@@ -26,6 +28,7 @@ const Checkbox: React.FunctionComponent<Props> = ({
 				type="checkbox"
 				id={id}
 				className="checkbox-button"
+				onBlur={onBlur}
 			/>
 			<label htmlFor={id} className="checkbox-label">
 				<span

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -1,0 +1,192 @@
+import React, { useState } from "react";
+import { useT } from "../i18n";
+import config from "./config";
+import { NursingHome, NursingHomeImageName } from "./types";
+
+import "../styles/ImageUpload.scss";
+
+interface ImageUploadProps {
+	nursingHome: NursingHome | null;
+	imageName: NursingHomeImageName | null | undefined;
+	useButton: boolean;
+	textAreaClass: string;
+	onRemove?: () => void;
+	onChange: (file: any) => void;
+	onCaptionChange?: (text: string) => void;
+}
+
+export const ImageUpload: React.FC<ImageUploadProps> = ({
+	nursingHome,
+	imageName,
+	useButton,
+	textAreaClass,
+	onRemove,
+	onChange,
+	onCaptionChange,
+}) => {
+	let hasImage = true;
+	let imageStateStr = "";
+
+	if (!imageName || !nursingHome || !nursingHome.pic_digests)
+		hasImage = false;
+	let digest: string = "";
+	let caption: string = "";
+	if (hasImage && nursingHome) {
+		digest = (nursingHome.pic_digests as any)[`${imageName}_hash`];
+		caption = (nursingHome.pic_captions as any)[`${imageName}_caption`];
+	}
+	if (!digest) hasImage = false;
+
+	if (hasImage && nursingHome) {
+		imageStateStr = `${config.API_URL}/nursing-homes/${nursingHome.id}/pics/${imageName}/${digest}`;
+	}
+
+	if (imageStateStr) hasImage = true;
+
+	const [srcUrl, setImage] = useState(imageStateStr);
+
+	const [captionState, setCaptionState] = useState(caption);
+
+	if (captionState && onCaptionChange) onCaptionChange(captionState);
+
+	const organizationLogoBtn = useT("organizationLogoBtn");
+	const uploadPlaceholder = useT("uploadPlaceholder");
+	const imageSizeWarning = useT("warningImageToLarge");
+	const emptyImageSpot = useT("emptyImageSpot");
+	const imageUploadTooltip = useT("imageUploadTooltip");
+	const swapImage = useT("swapImage");
+	const remove = useT("remove");
+
+	const handleImageChange = (
+		event: React.ChangeEvent<HTMLInputElement>,
+	): void => {
+		let file = new Blob();
+
+		if (event.target.files && event.target.files.length > 0) {
+			file = event.target.files[0];
+
+			if (file.size < 4200000) {
+				const reader = new FileReader();
+				reader.onloadend = e => {
+					onChange(reader.result);
+					setImage(reader.result as string);
+				};
+				reader.readAsDataURL(file);
+			} else {
+				alert(imageSizeWarning);
+			}
+		}
+	};
+
+	const handleCaptionChange = (
+		event: React.ChangeEvent<HTMLTextAreaElement>,
+	): void => {
+		if (onCaptionChange && event.target.value.length < 201) {
+			onCaptionChange(event.target.value);
+			setCaptionState(event.target.value);
+		}
+	};
+
+	const handleRemove = (
+		event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+	): void => {
+		if (onRemove) onRemove();
+		setImage("");
+	};
+
+	if (!srcUrl)
+		return (
+			<div className="nursinghome-upload-container">
+				<div className="nursinghome-upload-img nursinghome-upload-placeholder">
+					<div className="nursinghome-upload-img-inner">
+						<div className="nursinghome-upload-img-inner-text">
+							{emptyImageSpot}
+						</div>
+						<input
+							type="file"
+							className={
+								useButton ? "input-button" : "input-hidden"
+							}
+							title={imageUploadTooltip}
+							onChange={handleImageChange}
+						/>
+					</div>
+					<button
+						type="submit"
+						className={useButton ? "btn" : "upload-button-hidden"}
+					>
+						{organizationLogoBtn}
+					</button>
+				</div>
+				<textarea
+					className={textAreaClass}
+					value={captionState}
+					name={(imageName as string) + "_caption"}
+					placeholder={uploadPlaceholder}
+					onChange={handleCaptionChange}
+				></textarea>
+			</div>
+		);
+	else
+		return (
+			<div
+				className={
+					"nursinghome-upload-container " +
+					(useButton ? "input-button-layout" : "input-hidden-layout")
+				}
+			>
+				<div className="nursinghome-upload-img">
+					<div
+						className="nursinghome-upload-img-inner"
+						style={{
+							backgroundImage: `url(${srcUrl})`,
+						}}
+					>
+						<div className="nursinghome-upload-img-hover">
+							<div
+								className={
+									useButton ? "input-button" : "input-hidden"
+								}
+							>
+								<div className="nursinghome-upload-img-change-text">
+									{swapImage}
+								</div>
+								<input
+									type="file"
+									title={imageUploadTooltip}
+									onChange={handleImageChange}
+								/>
+							</div>
+							<div
+								className={
+									useButton
+										? "nursinghome-upload-button-remove"
+										: "nursinghome-upload-hidden-remove"
+								}
+								onClick={handleRemove}
+							>
+								<div className="nursinghome-upload-img-remove-text">
+									{remove}
+								</div>
+							</div>
+						</div>
+					</div>
+					<button
+						type="submit"
+						className={useButton ? "btn" : "upload-button-hidden"}
+					>
+						{organizationLogoBtn}
+					</button>
+				</div>
+				<textarea
+					className={textAreaClass}
+					value={captionState}
+					name={(imageName as string) + "_caption"}
+					placeholder={uploadPlaceholder}
+					onChange={handleCaptionChange}
+				></textarea>
+			</div>
+		);
+};
+
+export default ImageUpload;

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -29,8 +29,10 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
 
 	if (!imageName || !nursingHome || !nursingHome.pic_digests)
 		hasImage = false;
-	let digest: string = "";
-	let caption: string = "";
+
+	let digest = "";
+	let caption = "";
+
 	if (hasImage && nursingHome) {
 		digest = (nursingHome.pic_digests as any)[`${imageName}_hash`];
 		caption = (nursingHome.pic_captions as any)[`${imageName}_caption`];

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, useEffect, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import { useT } from "../i18n";
 import "../styles/PageUpdate.scss";
 import Radio from "./Radio";
@@ -498,8 +498,8 @@ const PageUpdate: FC = () => {
 	const handleInputChange = (
 		key: string,
 		data:
-			| ChangeEvent<HTMLInputElement>
-			| ChangeEvent<HTMLTextAreaElement>
+			| React.ChangeEvent<HTMLInputElement>
+			| React.ChangeEvent<HTMLTextAreaElement>
 			| boolean,
 	) => {
 		if (nursingHome) {
@@ -508,11 +508,10 @@ const PageUpdate: FC = () => {
 			} else {
 				const { value, type } = data.target;
 
-				if (type === "number") {
-					setNursingHome({ ...nursingHome, [key]: parseInt(value) });
-				} else {
-					setNursingHome({ ...nursingHome, [key]: value });
-				}
+				setNursingHome({
+					...nursingHome,
+					[key]: type === "number" ? parseInt(value) : value,
+				});
 			}
 		}
 	};

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -434,9 +434,7 @@ const PageUpdate: FC = () => {
 				type: InputTypes.textarea,
 				name: "apartment_count_info",
 				description: helperApartmentCountInfo,
-				required: true,
-				valid: false,
-				touched: false,
+				maxlength: 300,
 			},
 			{
 				label: labelApartmentSize + " (m²)",
@@ -466,9 +464,7 @@ const PageUpdate: FC = () => {
 				type: InputTypes.textarea,
 				name: "rent_info",
 				description: helperRentInfo,
-				required: true,
-				valid: false,
-				touched: false,
+				maxlength: 200,
 			},
 			{
 				label: labelServiceLanguage,
@@ -564,9 +560,6 @@ const PageUpdate: FC = () => {
 				type: InputTypes.url,
 				name: "activities_link",
 				description: helperActivitiesLink,
-				required: true,
-				valid: false,
-				touched: false,
 			},
 			{
 				label: labelOutdoorActivies,
@@ -579,9 +572,6 @@ const PageUpdate: FC = () => {
 				label: labelLinkMoreOutdoorInfo,
 				type: InputTypes.url,
 				name: "outdoors_possibilities_link",
-				required: true,
-				valid: false,
-				touched: false,
 			},
 		],
 		accessibilityFields: [

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -555,6 +555,7 @@ const PageUpdate: FC = () => {
 				delete transformNursingHomeData.rating;
 				delete transformNursingHomeData.geolocation;
 				delete transformNursingHomeData.has_vacancy;
+				delete transformNursingHomeData.basic_update_key;
 
 				const nursingHomeUpdateData: NursingHomeUpdateData = transformNursingHomeData;
 

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -268,7 +268,7 @@ const PageUpdate: FC = () => {
 				name: "language_info",
 			},
 		],
-		contactFields: [
+		addressFields: [
 			{
 				label: labelAddress,
 				type: InputTypes.text,
@@ -301,6 +301,8 @@ const PageUpdate: FC = () => {
 				valid: false,
 				touched: false,
 			},
+		],
+		contactFields: [
 			{
 				label: labelWebpage,
 				type: InputTypes.url,
@@ -930,6 +932,15 @@ const PageUpdate: FC = () => {
 							</div>
 							<div className="page-update-section">
 								<h3>{labelContactInfo}</h3>
+								<div className="page-update-columns">
+									{form.addressFields.map((field, index) =>
+										getInputElement(
+											field,
+											"addressFields",
+											index,
+										),
+									)}
+								</div>
 								{form.contactFields.map((field, index) =>
 									getInputElement(
 										field,

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -217,6 +217,23 @@ const PageUpdate: FC = () => {
 	const labelFoodHeader = useT("foodHeader");
 	const labelYes = useT("filterYes");
 	const labelNo = useT("filterNo");
+	const labelSummary = useT("summary");
+	const labelBuildingInfo = useT("buildingInfo");
+	const labelApartmentCountInfo = useT("apartmentCountInfo");
+	const labelApartmentsHaveBathroom = useT("apartmentsHaveBathroom");
+	const labelRentInfo = useT("rentInfo");
+	const labelLanguageInfo = useT("languageInfo");
+	const labelAddress = useT("address");
+	const labelPostalCode = useT("postalCode");
+	const labelCity = useT("city");
+	const labelDistrict = useT("district");
+	const labelArrivalGuidePublicTransit = useT("arrivalGuidePublicTransit");
+	const labelArrivalGuideCar = useT("arrivalGuideCar");
+	const labelContactName = useT("contactName");
+	const labelContactTitle = useT("contactTitle");
+	const labelContactPhone = useT("contactPhone");
+	const labelContactEmail = useT("contactEmail");
+	const labelContactPhoneInfo = useT("contactPhoneInfo");
 
 	const updatePopupSaved = useT("saved");
 	const updatePopupSaving = useT("saving");
@@ -234,7 +251,7 @@ const PageUpdate: FC = () => {
 	if (nursingHome) {
 		basicFields = [
 			{
-				label: "Yhteenveto",
+				label: labelSummary,
 				type: InputTypes.textarea,
 				name: "summary",
 				model: nursingHome.summary,
@@ -262,7 +279,7 @@ const PageUpdate: FC = () => {
 				model: nursingHome.construction_year,
 			},
 			{
-				label: "Lisätietoja rakennuksesta",
+				label: labelBuildingInfo,
 				type: InputTypes.textarea,
 				name: "building_info",
 				model: nursingHome.building_info,
@@ -274,7 +291,7 @@ const PageUpdate: FC = () => {
 				model: nursingHome.apartment_count,
 			},
 			{
-				label: "Lisätietoja asuntojen määrästä",
+				label: labelApartmentCountInfo,
 				type: InputTypes.textarea,
 				name: "apartment_count_info",
 				model: nursingHome.apartment_count_info,
@@ -286,7 +303,7 @@ const PageUpdate: FC = () => {
 				model: nursingHome.apartment_square_meters,
 			},
 			{
-				label: "Asunnoissa oma kylpyhuone",
+				label: labelApartmentsHaveBathroom,
 				type: InputTypes.checkbox,
 				name: "apartments_have_bathroom",
 				model: nursingHome.apartments_have_bathroom,
@@ -298,7 +315,7 @@ const PageUpdate: FC = () => {
 				model: nursingHome.rent,
 			},
 			{
-				label: "Lisätietoja vuokrasta",
+				label: labelRentInfo,
 				type: InputTypes.textarea,
 				name: "rent_info",
 				model: nursingHome.rent_info,
@@ -310,7 +327,7 @@ const PageUpdate: FC = () => {
 				model: nursingHome.language,
 			},
 			{
-				label: "Lisätietoja palvelukielestä",
+				label: labelLanguageInfo,
 				type: InputTypes.textarea,
 				name: "language_info",
 				model: nursingHome.language_info,
@@ -325,25 +342,25 @@ const PageUpdate: FC = () => {
 
 		contactFields = [
 			{
-				label: "Katuosoite",
+				label: labelAddress,
 				type: InputTypes.text,
 				name: "address",
 				model: nursingHome.address,
 			},
 			{
-				label: "Postinumero",
+				label: labelPostalCode,
 				type: InputTypes.text,
 				name: "postal_code",
 				model: nursingHome.postal_code,
 			},
 			{
-				label: "Kaupunki",
+				label: labelCity,
 				type: InputTypes.text,
 				name: "city",
 				model: nursingHome.city,
 			},
 			{
-				label: "Kaupunginosa",
+				label: labelDistrict,
 				type: InputTypes.text,
 				name: "district",
 				model: nursingHome.district,
@@ -355,13 +372,13 @@ const PageUpdate: FC = () => {
 				model: nursingHome.www,
 			},
 			{
-				label: "Saapuminen julkisilla kulkuyhteyksillä",
+				label: labelArrivalGuidePublicTransit,
 				type: InputTypes.textarea,
 				name: "arrival_guide_public_transit",
 				model: nursingHome.arrival_guide_public_transit,
 			},
 			{
-				label: "Saapuminen autolla",
+				label: labelArrivalGuideCar,
 				type: InputTypes.textarea,
 				name: "arrival_guide_car",
 				model: nursingHome.arrival_guide_car,
@@ -424,31 +441,31 @@ const PageUpdate: FC = () => {
 				model: nursingHome.tour_info,
 			},
 			{
-				label: "Yhteyshenkilön nimi",
+				label: labelContactName,
 				type: InputTypes.text,
 				name: "contact_name",
 				model: nursingHome.contact_name,
 			},
 			{
-				label: "Yhteyshenkilön titteli",
+				label: labelContactTitle,
 				type: InputTypes.text,
 				name: "contact_title",
 				model: nursingHome.contact_title,
 			},
 			{
-				label: "Yhteyshenkilön puhelinnumero",
+				label: labelContactPhone,
 				type: InputTypes.tel,
 				name: "contact_phone",
 				model: nursingHome.contact_phone,
 			},
 			{
-				label: "Yhteyshenkilön sähköposti",
+				label: labelContactEmail,
 				type: InputTypes.email,
 				name: "email",
 				model: nursingHome.email,
 			},
 			{
-				label: "Lisätietoja yhteyshenkilön puhelinnumerosta",
+				label: labelContactPhoneInfo,
 				type: InputTypes.textarea,
 				name: "contact_phone_info",
 				model: nursingHome.contact_phone_info,

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -35,6 +35,7 @@ type NursingHomeUpdateData = Omit<
 	| "has_vacancy"
 	| "basic_update_key"
 >;
+
 interface VacancyStatus {
 	has_vacancy: boolean;
 	vacancy_last_updated_at: string | null;
@@ -104,18 +105,20 @@ const requestNursingHomeUpdate = async (
 const PageUpdate: FC = () => {
 	const { id, key } = useParams<NursingHomeRouteParams>();
 
+	if (!id || !key) throw new Error("Invalid URL!");
+
 	const [nursingHome, setNursingHome] = useState<NursingHome | null>(null);
 	const [vacancyStatus, setVacancyStatus] = useState<VacancyStatus | null>(
 		null,
 	);
+	const [hasVacancy, setHasVacancy] = useState<boolean>(false);
 	const [popupState, setPopupState] = useState<
 		null | "saving" | "saved" | "invalid"
 	>(null);
-	const [hasVacancy, setHasVacancy] = useState<boolean>(false);
 
 	const labelOwner = useT("ownerOrganisation");
 	const labelAra = useT("filterAraLabel");
-	const labelYearofConst = useT("yearofConst");
+	const labelYearOfConst = useT("yearofConst");
 	const labelNumApartments = useT("numTotalApartments");
 	const labelApartmentSize = useT("apartmentSize");
 	const labelRent = useT("rent");
@@ -126,14 +129,14 @@ const PageUpdate: FC = () => {
 	const labelFoodMoreInfo = useT("foodMoreInfo");
 	const labelLinkMenu = useT("linkMenu");
 	const labelActivies = useT("activies");
-	const labelLinkMoreInfoActivies = useT("linkMoreInfoActivies");
+	const labelLinkMoreActiviesInfo = useT("linkMoreInfoActivies");
 	const labelOutdoorActivies = useT("outdoorActivies");
-	const labelLinkMoreInfoOutdoor = useT("linkMoreInfoOutdoor");
+	const labelLinkMoreOutdoorInfo = useT("linkMoreInfoOutdoor");
 	const labelVisitingInfo = useT("visitingInfo");
 	const labelAccessibility = useT("accessibility");
 	const labelAccessibilityInfo = useT("accessibilityInfo");
 	const labelPersonnel = useT("personnel");
-	const labelLinkMoreInfoPersonnel = useT("linkMoreInfoPersonnel");
+	const labelLinkMorePersonnelInfo = useT("linkMoreInfoPersonnel");
 	const labelOtherServices = useT("otherServices");
 	const labelBasicInformation = useT("basicInformation");
 	const labelContactInfo = useT("contactInfo");
@@ -150,8 +153,8 @@ const PageUpdate: FC = () => {
 	const labelPostalCode = useT("postalCode");
 	const labelCity = useT("city");
 	const labelDistrict = useT("district");
-	const labelArrivalGuidePublicTransit = useT("arrivalGuidePublicTransit");
-	const labelArrivalGuideCar = useT("arrivalGuideCar");
+	const labelArrivalPublicTransit = useT("arrivalPublicTransit");
+	const labelArrivalCar = useT("arrivalCar");
 	const labelContactName = useT("contactName");
 	const labelContactTitle = useT("contactTitle");
 	const labelContactPhone = useT("contactPhone");
@@ -200,8 +203,6 @@ const PageUpdate: FC = () => {
 	const fieldsWithAsteriskAreMandatory = useT(
 		"fieldsWithAsteriskAreMandatory",
 	);
-
-	if (!id || !key) throw new Error("Invalid URL!");
 
 	useEffect(() => {
 		axios
@@ -267,63 +268,7 @@ const PageUpdate: FC = () => {
 				name: "lah",
 			},
 		],
-		addressFields: [
-			{
-				label: labelAddress,
-				type: InputTypes.text,
-				name: "address",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelPostalCode,
-				type: InputTypes.text,
-				name: "postal_code",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelCity,
-				type: InputTypes.text,
-				name: "city",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelDistrict,
-				type: InputTypes.text,
-				name: "district",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-		],
 		contactFields: [
-			{
-				label: labelWebpage,
-				type: InputTypes.url,
-				name: "www",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelArrivalGuidePublicTransit,
-				type: InputTypes.textarea,
-				name: "arrival_guide_public_transit",
-				maxlength: 200,
-			},
-			{
-				label: labelArrivalGuideCar,
-				type: InputTypes.textarea,
-				name: "arrival_guide_car",
-				maxlength: 200,
-			},
-		],
-		nursingHomeContactFields: [
 			{
 				label: labelContactDescription,
 				type: InputTypes.textarea,
@@ -371,7 +316,63 @@ const PageUpdate: FC = () => {
 				maxlength: 200,
 			},
 		],
-		basicFields: [
+		addressFields: [
+			{
+				label: labelAddress,
+				type: InputTypes.text,
+				name: "address",
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelPostalCode,
+				type: InputTypes.text,
+				name: "postal_code",
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelCity,
+				type: InputTypes.text,
+				name: "city",
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelDistrict,
+				type: InputTypes.text,
+				name: "district",
+				required: true,
+				valid: false,
+				touched: false,
+			},
+		],
+		guideFields: [
+			{
+				label: labelWebpage,
+				type: InputTypes.url,
+				name: "www",
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelArrivalPublicTransit,
+				type: InputTypes.textarea,
+				name: "arrival_guide_public_transit",
+				maxlength: 200,
+			},
+			{
+				label: labelArrivalCar,
+				type: InputTypes.textarea,
+				name: "arrival_guide_car",
+				maxlength: 200,
+			},
+		],
+		infoFields: [
 			{
 				label: labelSummary,
 				type: InputTypes.textarea,
@@ -406,7 +407,7 @@ const PageUpdate: FC = () => {
 				touched: false,
 			},
 			{
-				label: labelYearofConst,
+				label: labelYearOfConst,
 				type: InputTypes.number,
 				name: "construction_year",
 				required: true,
@@ -559,7 +560,7 @@ const PageUpdate: FC = () => {
 				touched: false,
 			},
 			{
-				label: labelLinkMoreInfoActivies,
+				label: labelLinkMoreActiviesInfo,
 				type: InputTypes.url,
 				name: "activities_link",
 				description: helperActivitiesLink,
@@ -575,7 +576,7 @@ const PageUpdate: FC = () => {
 				maxlength: 200,
 			},
 			{
-				label: labelLinkMoreInfoOutdoor,
+				label: labelLinkMoreOutdoorInfo,
 				type: InputTypes.url,
 				name: "outdoors_possibilities_link",
 				required: true,
@@ -601,7 +602,7 @@ const PageUpdate: FC = () => {
 				maxlength: 400,
 			},
 			{
-				label: labelLinkMoreInfoPersonnel,
+				label: labelLinkMorePersonnelInfo,
 				type: InputTypes.url,
 				name: "staff_satisfaction_info",
 				description: helperStaffSatisfaction,
@@ -738,15 +739,18 @@ const PageUpdate: FC = () => {
 	): void => {
 		if (nursingHome) {
 			const { name, type } = field;
+			const shouldValidate = "touched" in field && "required" in field;
 
-			const fields = [...form[section]];
-			const index = fields.findIndex(input => input.name === name);
+			if (shouldValidate) {
+				const fields = [...form[section]];
+				const index = fields.findIndex(input => input.name === name);
 
-			const validField = validateField(value);
+				const validField = validateField(value);
 
-			fields[index] = { ...field, touched: true, valid: validField };
+				fields[index] = { ...field, touched: true, valid: validField };
 
-			setForm({ ...form, [section]: fields });
+				setForm({ ...form, [section]: fields });
+			}
 
 			setNursingHome({
 				...nursingHome,
@@ -1094,13 +1098,12 @@ const PageUpdate: FC = () => {
 							</div>
 							<div className="page-update-section">
 								<h3>{labelVisitingInfo}</h3>
-								{form.nursingHomeContactFields.map(
-									(field, index) =>
-										getInputElement(
-											field,
-											"nursingHomeContactFields",
-											index,
-										),
+								{form.contactFields.map((field, index) =>
+									getInputElement(
+										field,
+										"contactFields",
+										index,
+									),
 								)}
 							</div>
 							<div className="page-update-section">
@@ -1114,22 +1117,18 @@ const PageUpdate: FC = () => {
 										),
 									)}
 								</div>
-								{form.contactFields.map((field, index) =>
+								{form.guideFields.map((field, index) =>
 									getInputElement(
 										field,
-										"contactFields",
+										"guideFields",
 										index,
 									),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelBasicInformation}</h3>
-								{form.basicFields.map((field, index) =>
-									getInputElement(
-										field,
-										"basicFields",
-										index,
-									),
+								{form.infoFields.map((field, index) =>
+									getInputElement(field, "infoFields", index),
 								)}
 							</div>
 							<div className="page-update-section">

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -704,11 +704,12 @@ const PageUpdate: FC = () => {
 							}
 						></textarea>
 						{field.required && formErrors[field.name] ? (
-							<span className="field-error">
-								{textFieldIsRequired}
-							</span>
+							<span className="icon"></span>
 						) : null}
 					</div>
+					{field.required && formErrors[field.name] ? (
+						<p className="help">{textFieldIsRequired}</p>
+					) : null}
 				</div>
 			);
 		} else if (field.type === "checkbox") {
@@ -778,11 +779,12 @@ const PageUpdate: FC = () => {
 							}
 						/>
 						{field.required && formErrors[field.name] ? (
-							<span className="field-error">
-								{textFieldIsRequired}
-							</span>
+							<span className="icon"></span>
 						) : null}
 					</div>
+					{field.required && formErrors[field.name] ? (
+						<p className="help">{textFieldIsRequired}</p>
+					) : null}
 				</div>
 			);
 		}

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -34,6 +34,8 @@ enum InputTypes {
 	checkbox = "checkbox",
 	email = "email",
 	url = "url",
+	tel = "tel",
+	radio = "radio",
 }
 
 const formatDate = (dateString: string | null): string => {
@@ -160,31 +162,33 @@ const PageUpdate: FC = () => {
 	const btnSave = useT("btnSave");
 	const cancel = useT("cancel");
 
-	const textOwner = useT("owner");
-	const textAra = useT("filterAraLabel");
-	const textYearofConst = useT("yearofConst");
-	const textNumApartments = useT("numApartments");
-	const textApartmentSize = useT("apartmentSize");
-	const textRent = useT("rent");
-	const textServiceLanguage = useT("serviceLanguage");
-	const textLAHapartments = useT("LAHapartments");
-	const textWebpage = useT("webpage");
-	const textCookingMethod = useT("cookingMethod");
-	const textFoodMoreInfo = useT("foodMoreInfo");
-	const textLinkMenu = useT("linkMenu");
-	const textActivies = useT("activies");
-	const textLinkMoreInfoActivies = useT("linkMoreInfoActivies");
-	const textOutdoorActivies = useT("outdoorActivies");
-	const textLinkMoreInfoOutdoor = useT("linkMoreInfoOutdoor");
-	const textVisitingInfo = useT("visitingInfo");
-	const textAccessibility = useT("accessibility");
-	const textPersonnel = useT("personnel");
-	const textLinkMoreInfoPersonnel = useT("linkMoreInfoPersonnel");
-	const textOtherServices = useT("otherServices");
-	const textNearbyServices = useT("nearbyServices");
-	const textBasicInformation = useT("basicInformation");
-	const textContactInfo = useT("contactInfo");
-	const textFoodHeader = useT("foodHeader");
+	const labelOwner = useT("owner");
+	const labelAra = useT("filterAraLabel");
+	const labelYearofConst = useT("yearofConst");
+	const labelNumApartments = useT("numApartments");
+	const labelApartmentSize = useT("apartmentSize");
+	const labelRent = useT("rent");
+	const labelServiceLanguage = useT("serviceLanguage");
+	const labelLAHapartments = useT("LAHapartments");
+	const labelWebpage = useT("webpage");
+	const labelCookingMethod = useT("cookingMethod");
+	const labelFoodMoreInfo = useT("foodMoreInfo");
+	const labelLinkMenu = useT("linkMenu");
+	const labelActivies = useT("activies");
+	const labelLinkMoreInfoActivies = useT("linkMoreInfoActivies");
+	const labelOutdoorActivies = useT("outdoorActivies");
+	const labelLinkMoreInfoOutdoor = useT("linkMoreInfoOutdoor");
+	const labelVisitingInfo = useT("visitingInfo");
+	const labelAccessibility = useT("accessibility");
+	const labelPersonnel = useT("personnel");
+	const labelLinkMoreInfoPersonnel = useT("linkMoreInfoPersonnel");
+	const labelOtherServices = useT("otherServices");
+	const labelNearbyServices = useT("nearbyServices");
+	const labelBasicInformation = useT("basicInformation");
+	const labelContactInfo = useT("contactInfo");
+	const labelFoodHeader = useT("foodHeader");
+	const labelYes = useT("filterYes");
+	const labelNo = useT("filterNo");
 
 	const updatePopupSaved = useT("saved");
 	const updatePopupSaving = useT("saving");
@@ -208,19 +212,19 @@ const PageUpdate: FC = () => {
 				value: nursingHome.summary,
 			},
 			{
-				label: textOwner,
+				label: labelOwner,
 				type: InputTypes.text,
 				name: "owner",
 				value: nursingHome.owner,
 			},
 			{
-				label: textAra,
-				type: InputTypes.checkbox,
+				label: labelAra,
+				type: InputTypes.radio,
 				name: "ara",
 				value: nursingHome.ara,
 			},
 			{
-				label: textYearofConst,
+				label: labelYearofConst,
 				type: InputTypes.number,
 				name: "construction_year",
 				value: nursingHome.construction_year,
@@ -232,7 +236,7 @@ const PageUpdate: FC = () => {
 				value: nursingHome.building_info,
 			},
 			{
-				label: textNumApartments,
+				label: labelNumApartments,
 				type: InputTypes.number,
 				name: "apartment_count",
 				value: nursingHome.apartment_count,
@@ -244,7 +248,7 @@ const PageUpdate: FC = () => {
 				value: nursingHome.apartment_count_info,
 			},
 			{
-				label: textApartmentSize,
+				label: labelApartmentSize,
 				type: InputTypes.text,
 				name: "apartment_square_meters",
 				value: nursingHome.apartment_square_meters,
@@ -256,7 +260,7 @@ const PageUpdate: FC = () => {
 				value: nursingHome.apartments_have_bathroom,
 			},
 			{
-				label: textRent,
+				label: labelRent,
 				type: InputTypes.text,
 				name: "rent",
 				value: nursingHome.rent,
@@ -268,7 +272,7 @@ const PageUpdate: FC = () => {
 				value: nursingHome.rent_info,
 			},
 			{
-				label: textServiceLanguage,
+				label: labelServiceLanguage,
 				type: InputTypes.text,
 				name: "language",
 				value: nursingHome.language,
@@ -280,7 +284,7 @@ const PageUpdate: FC = () => {
 				value: nursingHome.language_info,
 			},
 			{
-				label: textLAHapartments,
+				label: labelLAHapartments,
 				type: InputTypes.checkbox,
 				name: "lah",
 				value: nursingHome.lah,
@@ -313,8 +317,8 @@ const PageUpdate: FC = () => {
 				value: nursingHome.district,
 			},
 			{
-				label: textWebpage,
-				type: InputTypes.text,
+				label: labelWebpage,
+				type: InputTypes.url,
 				name: "www",
 				value: nursingHome.www,
 			},
@@ -334,19 +338,19 @@ const PageUpdate: FC = () => {
 
 		foodFields = [
 			{
-				label: textCookingMethod,
+				label: labelCookingMethod,
 				type: InputTypes.text,
 				name: "meals_preparation",
 				value: nursingHome.meals_preparation,
 			},
 			{
-				label: textFoodMoreInfo,
+				label: labelFoodMoreInfo,
 				type: InputTypes.textarea,
 				name: "meals_info",
 				value: nursingHome.meals_info,
 			},
 			{
-				label: textLinkMenu,
+				label: labelLinkMenu,
 				type: InputTypes.url,
 				name: "menu_link",
 				value: nursingHome.menu_link,
@@ -355,25 +359,25 @@ const PageUpdate: FC = () => {
 
 		activitiesFields = [
 			{
-				label: textActivies,
+				label: labelActivies,
 				type: InputTypes.textarea,
 				name: "activities_info",
 				value: nursingHome.activities_info,
 			},
 			{
-				label: textLinkMoreInfoActivies,
+				label: labelLinkMoreInfoActivies,
 				type: InputTypes.url,
 				name: "activities_link",
 				value: nursingHome.activities_link,
 			},
 			{
-				label: textOutdoorActivies,
+				label: labelOutdoorActivies,
 				type: InputTypes.textarea,
 				name: "outdoors_possibilities_info",
 				value: nursingHome.outdoors_possibilities_info,
 			},
 			{
-				label: textLinkMoreInfoOutdoor,
+				label: labelLinkMoreInfoOutdoor,
 				type: InputTypes.url,
 				name: "outdoors_possibilities_link",
 				value: nursingHome.outdoors_possibilities_link,
@@ -382,7 +386,7 @@ const PageUpdate: FC = () => {
 
 		nursingHomeContactFields = [
 			{
-				label: textVisitingInfo,
+				label: labelVisitingInfo,
 				type: InputTypes.textarea,
 				name: "tour_info",
 				value: nursingHome.tour_info,
@@ -401,7 +405,7 @@ const PageUpdate: FC = () => {
 			},
 			{
 				label: "Yhteyshenkilön puhelinnumero",
-				type: InputTypes.text,
+				type: InputTypes.tel,
 				name: "contact_phone",
 				value: nursingHome.contact_phone,
 			},
@@ -421,7 +425,7 @@ const PageUpdate: FC = () => {
 
 		accessibilityFields = [
 			{
-				label: textAccessibility,
+				label: labelAccessibility,
 				type: InputTypes.textarea,
 				name: "accessibility_info",
 				value: nursingHome.accessibility_info,
@@ -430,13 +434,13 @@ const PageUpdate: FC = () => {
 
 		staffFields = [
 			{
-				label: textPersonnel,
+				label: labelPersonnel,
 				type: InputTypes.textarea,
 				name: "staff_info",
 				value: nursingHome.staff_info,
 			},
 			{
-				label: textLinkMoreInfoPersonnel,
+				label: labelLinkMoreInfoPersonnel,
 				type: InputTypes.url,
 				name: "staff_satisfaction_info",
 				value: nursingHome.staff_satisfaction_info,
@@ -445,7 +449,7 @@ const PageUpdate: FC = () => {
 
 		otherServicesFields = [
 			{
-				label: textOtherServices,
+				label: labelOtherServices,
 				type: InputTypes.textarea,
 				name: "other_services",
 				value: nursingHome.other_services,
@@ -454,7 +458,7 @@ const PageUpdate: FC = () => {
 
 		nearbyServicesFields = [
 			{
-				label: textNearbyServices,
+				label: labelNearbyServices,
 				type: InputTypes.textarea,
 				name: "nearby_services",
 				value: nursingHome.nearby_services,
@@ -496,22 +500,17 @@ const PageUpdate: FC = () => {
 
 	const handleInputChange = (
 		key: string,
-		data:
-			| React.ChangeEvent<HTMLInputElement>
-			| React.ChangeEvent<HTMLTextAreaElement>
-			| boolean,
+		type: string,
+		value: string | number | boolean,
 	): void => {
 		if (nursingHome) {
-			if (typeof data === "boolean") {
-				setNursingHome({ ...nursingHome, [key]: data });
-			} else {
-				const { value, type } = data.target;
-
-				setNursingHome({
-					...nursingHome,
-					[key]: type === "number" ? parseInt(value) : value,
-				});
-			}
+			setNursingHome({
+				...nursingHome,
+				[key]:
+					type === "number" && typeof value === "string"
+						? parseInt(value)
+						: value,
+			});
 		}
 	};
 
@@ -527,7 +526,13 @@ const PageUpdate: FC = () => {
 						value={(field.value as string) || ""}
 						name={field.name}
 						id={field.name}
-						onChange={event => handleInputChange(field.name, event)}
+						onChange={event =>
+							handleInputChange(
+								field.name,
+								field.type,
+								event.target.value,
+							)
+						}
 					></textarea>
 				</div>
 			);
@@ -541,12 +546,54 @@ const PageUpdate: FC = () => {
 						name={field.name}
 						id={field.name}
 						onChange={checked =>
-							handleInputChange(field.name, checked)
+							handleInputChange(field.name, field.type, checked)
 						}
 						isChecked={(field.value as boolean) || false}
 					>
 						{field.label}
 					</Checkbox>
+				</div>
+			);
+		} else if (field.type === "radio") {
+			return (
+				<div
+					className="page-update-input"
+					key={`${field.name}_${index}`}
+				>
+					<Radio
+						id={`${field.name}-true`}
+						name={field.name}
+						isSelected={field.value === labelYes}
+						value={labelYes}
+						onChange={isChecked => {
+							if (isChecked) {
+								handleInputChange(
+									field.name,
+									field.type,
+									labelYes,
+								);
+							}
+						}}
+					>
+						{labelAra}
+					</Radio>
+					<Radio
+						id={`${field.name}-false`}
+						name={field.name}
+						isSelected={field.value !== labelYes}
+						value={labelNo}
+						onChange={isChecked => {
+							if (isChecked) {
+								handleInputChange(
+									field.name,
+									field.type,
+									labelNo,
+								);
+							}
+						}}
+					>
+						Ei {labelAra}
+					</Radio>
 				</div>
 			);
 		} else {
@@ -561,7 +608,13 @@ const PageUpdate: FC = () => {
 						name={field.name}
 						id={field.name}
 						type={field.type}
-						onChange={event => handleInputChange(field.name, event)}
+						onChange={event =>
+							handleInputChange(
+								field.name,
+								field.type,
+								event.target.value,
+							)
+						}
 					/>
 				</div>
 			);
@@ -701,55 +754,55 @@ const PageUpdate: FC = () => {
 							</div>
 						</div>
 						<div className="page-update-section">
-							<h3>{textBasicInformation}</h3>
+							<h3>{labelBasicInformation}</h3>
 							{basicFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>{textContactInfo}</h3>
+							<h3>{labelContactInfo}</h3>
 							{contactFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>Ruoka</h3>
+							<h3>{labelFoodHeader}</h3>
 							{foodFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>{textFoodHeader}</h3>
+							<h3>{labelActivies}</h3>
 							{activitiesFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>{textVisitingInfo}</h3>
+							<h3>{labelVisitingInfo}</h3>
 							{nursingHomeContactFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>{textAccessibility}</h3>
+							<h3>{labelAccessibility}</h3>
 							{accessibilityFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>{textPersonnel}</h3>
+							<h3>{labelPersonnel}</h3>
 							{staffFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>{textOtherServices}</h3>
+							<h3>{labelOtherServices}</h3>
 							{otherServicesFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>{textNearbyServices}</h3>
+							<h3>{labelNearbyServices}</h3>
 							{nearbyServicesFields.map((field, index) =>
 								getInputElement(field, index),
 							)}

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -90,8 +90,6 @@ const PageUpdate: FC = () => {
 		axios
 			.get(`${config.API_URL}/nursing-homes/${id}`)
 			.then((response: GetNursingHomeResponse) => {
-				console.log(response.data);
-
 				setNursingHome(response.data);
 			})
 			.catch(e => {
@@ -117,6 +115,10 @@ const PageUpdate: FC = () => {
 				});
 		}
 	}, [id, key, popupState, vacancyStatus]);
+
+	useEffect(() => {
+		console.log(nursingHome);
+	}, [nursingHome]);
 
 	const imageState = [
 		{ name: "overview_outside", remove: false, value: "", text: "" },
@@ -220,7 +222,7 @@ const PageUpdate: FC = () => {
 			},
 			{
 				label: textYearofConst,
-				type: InputTypes.text,
+				type: InputTypes.number,
 				name: "construction_year",
 				value: nursingHome.construction_year,
 			},
@@ -495,11 +497,7 @@ const PageUpdate: FC = () => {
 
 	const handleInputChange = (key: string, value: string | boolean) => {
 		if (nursingHome) {
-			const updateNursingHome = { ...nursingHome };
-
-			(updateNursingHome as any)[key] = value;
-
-			setNursingHome(updateNursingHome);
+			setNursingHome({ ...nursingHome, [key]: value });
 		}
 	};
 
@@ -512,7 +510,7 @@ const PageUpdate: FC = () => {
 				>
 					<label htmlFor={field.name}>{field.label}</label>
 					<textarea
-						defaultValue={(field.value as string) || ""}
+						value={(field.value as string) || ""}
 						name={field.name}
 						id={field.name}
 						onChange={event =>
@@ -546,7 +544,7 @@ const PageUpdate: FC = () => {
 				>
 					<label htmlFor={field.name}>{field.label}</label>
 					<input
-						defaultValue={(field.value as string) || ""}
+						value={(field.value as string) || ""}
 						name={field.name}
 						id={field.name}
 						type={field.type}

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -132,10 +132,6 @@ const PageUpdate: FC = () => {
 	>(null);
 	const [hasVacancy, setHasVacancy] = useState<boolean>(false);
 
-	// const [formErrors, setFormErrors] = useState<{ [key: string]: boolean }>(
-	// 	{},
-	// );
-
 	if (!id || !key) throw new Error("Invalid URL!");
 
 	useEffect(() => {

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -50,11 +50,13 @@ interface InputField {
 	label: string;
 	type: InputTypes;
 	name: NursingHomeKey;
+	description?: string;
 	buttons?: { value: string | boolean; label: string }[];
 	required?: boolean;
 	valid?: boolean;
 	touched?: boolean;
 	change?: (arg: InputFieldValue) => void;
+	maxlength?: number;
 }
 
 const formatDate = (dateString: string | null): string => {
@@ -112,14 +114,14 @@ const PageUpdate: FC = () => {
 	>(null);
 	const [hasVacancy, setHasVacancy] = useState<boolean>(false);
 
-	const labelOwner = useT("owner");
+	const labelOwner = useT("ownerOrganisation");
 	const labelAra = useT("filterAraLabel");
 	const labelYearofConst = useT("yearofConst");
-	const labelNumApartments = useT("numApartments");
+	const labelNumApartments = useT("numTotalApartments");
 	const labelApartmentSize = useT("apartmentSize");
 	const labelRent = useT("rent");
 	const labelServiceLanguage = useT("serviceLanguage");
-	const labelLAHapartments = useT("LAHapartments");
+	const labelHasLAHapartments = useT("hasLAHapartments");
 	const labelWebpage = useT("webpage");
 	const labelCookingMethod = useT("cookingMethod");
 	const labelFoodMoreInfo = useT("foodMoreInfo");
@@ -130,6 +132,7 @@ const PageUpdate: FC = () => {
 	const labelLinkMoreInfoOutdoor = useT("linkMoreInfoOutdoor");
 	const labelVisitingInfo = useT("visitingInfo");
 	const labelAccessibility = useT("accessibility");
+	const labelAccessibilityInfo = useT("accessibilityInfo");
 	const labelPersonnel = useT("personnel");
 	const labelLinkMoreInfoPersonnel = useT("linkMoreInfoPersonnel");
 	const labelOtherServices = useT("otherServices");
@@ -157,15 +160,12 @@ const PageUpdate: FC = () => {
 	const labelContactEmail = useT("contactEmail");
 	const labelContactPhoneInfo = useT("contactPhoneInfo");
 	const labelContactDescription = useT("contactDescription");
-	const title = useT("pageUpdateTitle");
+	const labelNursingHomeName = useT("nursingHomeName");
+	const title = useT("updateNursingHomeTitle");
 	const freeApartmentsStatus = useT("freeApartmentsStatus");
-
-	const intro = useT("pageUpdateIntro");
 	const labelTrue = useT("vacancyTrue");
 	const labelFalse = useT("vacancyFalse");
 	const loadingText = useT("loadingText");
-	const nursingHomeName = useT("nursingHome");
-	const status = useT("status");
 	const lastUpdate = useT("lastUpdate");
 	const noUpdate = useT("noUpdate");
 	const btnSave = useT("btnSave");
@@ -181,6 +181,7 @@ const PageUpdate: FC = () => {
 				label: labelSummary,
 				type: InputTypes.textarea,
 				name: "summary",
+				description: "Hoivakodin palvelulupaus",
 				required: true,
 				valid: false,
 				touched: false,
@@ -200,6 +201,7 @@ const PageUpdate: FC = () => {
 				buttons: [
 					{ value: labelYes, label: labelYes },
 					{ value: labelNo, label: labelNo },
+					{ value: "Osittain", label: "Osa paikoista" },
 				],
 			},
 			{
@@ -214,6 +216,9 @@ const PageUpdate: FC = () => {
 				label: labelBuildingInfo,
 				type: InputTypes.textarea,
 				name: "building_info",
+				description:
+					"Tässä voit kertoa mahdollisista tehdyistä tai tulossa olevista peruskorjauksista, laajennuksista jne.",
+				maxlength: 200,
 			},
 			{
 				label: labelNumApartments,
@@ -227,11 +232,18 @@ const PageUpdate: FC = () => {
 				label: labelApartmentCountInfo,
 				type: InputTypes.textarea,
 				name: "apartment_count_info",
+				description:
+					"Tässä voit kertoa esim. minkä kokoisiin ryhmäkoteihin hoivakoti jakaantuu ja kuinka monta asuntoa on per kerros.",
+				maxlength: 300,
+				required: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelApartmentSize + " (m²)",
 				type: InputTypes.text,
 				name: "apartment_square_meters",
+				description: "Esim. 18-25",
 				required: true,
 				valid: false,
 				touched: false,
@@ -245,6 +257,7 @@ const PageUpdate: FC = () => {
 				label: labelRent + " (€ / kk)",
 				type: InputTypes.text,
 				name: "rent",
+				description: "Esim. 700-800",
 				required: true,
 				valid: false,
 				touched: false,
@@ -253,6 +266,9 @@ const PageUpdate: FC = () => {
 				label: labelRentInfo,
 				type: InputTypes.textarea,
 				name: "rent_info",
+				description:
+					"Mitä yhteisiä tiloja asiakkaan vuokraan sisältyy?",
+				maxlength: 200,
 			},
 			{
 				label: labelServiceLanguage,
@@ -266,6 +282,9 @@ const PageUpdate: FC = () => {
 				label: labelLanguageInfo,
 				type: InputTypes.textarea,
 				name: "language_info",
+				description:
+					"Esim. lisätietoa henkilökunnan muusta kielitaidosta.",
+				maxlength: 200,
 			},
 		],
 		addressFields: [
@@ -315,14 +334,24 @@ const PageUpdate: FC = () => {
 				label: labelArrivalGuidePublicTransit,
 				type: InputTypes.textarea,
 				name: "arrival_guide_public_transit",
+				maxlength: 200,
 			},
 			{
 				label: labelArrivalGuideCar,
 				type: InputTypes.textarea,
 				name: "arrival_guide_car",
+				maxlength: 200,
 			},
 		],
 		foodFields: [
+			{
+				label: labelLinkMenu,
+				type: InputTypes.url,
+				name: "menu_link",
+				required: true,
+				valid: false,
+				touched: false,
+			},
 			{
 				label: labelCookingMethod,
 				type: InputTypes.text,
@@ -335,17 +364,9 @@ const PageUpdate: FC = () => {
 				label: labelFoodMoreInfo,
 				type: InputTypes.textarea,
 				name: "meals_info",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelLinkMenu,
-				type: InputTypes.url,
-				name: "menu_link",
-				required: true,
-				valid: false,
-				touched: false,
+				maxlength: 200,
+				description:
+					"Tässä voi halutessasi antaa lisätietoja ruuan valmistukseen ja ruokailuun liittyen.",
 			},
 		],
 		activitiesFields: [
@@ -356,11 +377,16 @@ const PageUpdate: FC = () => {
 				required: true,
 				valid: false,
 				touched: false,
+				description:
+					"Kuvaus hoivakodissa järjestettävästä toiminnasta.",
+				maxlength: 400,
 			},
 			{
 				label: labelLinkMoreInfoActivies,
 				type: InputTypes.url,
 				name: "activities_link",
+				description:
+					"Jos hoivakodin sivuilla on esim. ulkoilukalenteri, laita sen linkki tähän.",
 				required: true,
 				valid: false,
 				touched: false,
@@ -369,14 +395,16 @@ const PageUpdate: FC = () => {
 				label: labelOutdoorActivies,
 				type: InputTypes.textarea,
 				name: "outdoors_possibilities_info",
-				required: true,
-				valid: false,
-				touched: false,
+				description:
+					"Kuvaa hoivakodin ulkoilumahdollisuuksia. Kuvaile esim. miten ulkoilua järjestetään ja miten asiakkaat ulkoilevat.",
+				maxlength: 200,
 			},
 			{
 				label: labelLinkMoreInfoOutdoor,
 				type: InputTypes.url,
 				name: "outdoors_possibilities_link",
+				description:
+					"Jos hoivakodin sivuilla on esim. ulkoilukalenteri, laita se tähän.",
 				required: true,
 				valid: false,
 				touched: false,
@@ -427,16 +455,17 @@ const PageUpdate: FC = () => {
 				label: labelContactPhoneInfo,
 				type: InputTypes.textarea,
 				name: "contact_phone_info",
+				maxlength: 200,
 			},
 		],
 		accessibilityFields: [
 			{
-				label: labelAccessibility,
+				label: labelAccessibilityInfo,
 				type: InputTypes.textarea,
 				name: "accessibility_info",
-				required: true,
-				valid: false,
-				touched: false,
+				description:
+					"Tähän voit tarvittaessa kirjoittaa esteettömyyttä koskevia lisätietoja.",
+				maxlength: 200,
 			},
 		],
 		staffFields: [
@@ -444,11 +473,16 @@ const PageUpdate: FC = () => {
 				label: labelPersonnel,
 				type: InputTypes.textarea,
 				name: "staff_info",
+				description:
+					"Kerro halutessasi henkilöstöstä, sen rakenteesta ja erityisosaamisesta",
+				maxlength: 400,
 			},
 			{
 				label: labelLinkMoreInfoPersonnel,
 				type: InputTypes.url,
 				name: "staff_satisfaction_info",
+				description:
+					"Lisää linkki jos hoivakodin sivuilla on tietoa henkilöstön tyytyväisyydestä (kyselyn tulokset tms.).",
 			},
 		],
 		otherServicesFields: [
@@ -456,6 +490,9 @@ const PageUpdate: FC = () => {
 				label: labelOtherServices,
 				type: InputTypes.textarea,
 				name: "other_services",
+				description:
+					"Kuvaa tähän mitä muita palvelukonseptiin kuulumattomia palveluita on saatavilla. Kerro myös mistä niiden hinnat löytyvät.",
+				maxlength: 200,
 			},
 		],
 		nearbyServicesFields: [
@@ -463,14 +500,22 @@ const PageUpdate: FC = () => {
 				label: labelNearbyServices,
 				type: InputTypes.textarea,
 				name: "nearby_services",
-				required: true,
-				valid: false,
-				touched: false,
+				description:
+					"Mitä palveluita löytyy hoivakodin läheltä esim. kauppa, kirjasto, ravintola jne.",
+				maxlength: 200,
 			},
 		],
 		vacancyFields: [
 			{
-				label: intro,
+				label: labelNursingHomeName,
+				type: InputTypes.text,
+				name: "name",
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: freeApartmentsStatus,
 				type: InputTypes.radio,
 				buttons: [
 					{ value: true, label: labelTrue },
@@ -482,7 +527,7 @@ const PageUpdate: FC = () => {
 				},
 			},
 			{
-				label: labelLAHapartments,
+				label: labelHasLAHapartments,
 				type: InputTypes.checkbox,
 				name: "lah",
 			},
@@ -524,22 +569,6 @@ const PageUpdate: FC = () => {
 		}
 	}, [id, key, popupState, vacancyStatus]);
 
-	const validateField = (value: any): boolean => {
-		return value !== null && value !== "";
-	};
-
-	const getAllFields = (): InputField[] => {
-		let fields: InputField[] = [];
-
-		const sections = Object.keys(form).map(section => form[section]);
-
-		for (const section of sections) {
-			fields = [...fields, ...section];
-		}
-
-		return fields;
-	};
-
 	const handleSubmit = async (
 		event: React.FormEvent<HTMLFormElement>,
 	): Promise<void> => {
@@ -552,7 +581,15 @@ const PageUpdate: FC = () => {
 				await requestVacancyStatusUpdate(id, key, hasVacancy);
 
 				if (nursingHome) {
-					const fields = getAllFields();
+					let fields: InputField[] = [];
+
+					const sections = Object.keys(form).map(
+						section => form[section],
+					);
+
+					for (const section of sections) {
+						fields = [...fields, ...section];
+					}
 
 					const formData: any = {};
 
@@ -573,8 +610,6 @@ const PageUpdate: FC = () => {
 
 				setPopupState("saved");
 				setVacancyStatus(null);
-			} else {
-				setPopupState("invalid");
 			}
 		} catch (error) {
 			console.error(error);
@@ -585,6 +620,16 @@ const PageUpdate: FC = () => {
 	const cancelEdit = (e: React.FormEvent<HTMLButtonElement>): void => {
 		e.preventDefault();
 		window.location.href = window.location.pathname + "/peruuta";
+	};
+
+	const validateField = <T extends NursingHome, K extends keyof T>(
+		value: T[K],
+	): boolean => {
+		if (typeof value === "string") {
+			return value.trim() !== "";
+		}
+
+		return value !== null;
 	};
 
 	const validateForm = (): void => {
@@ -621,47 +666,23 @@ const PageUpdate: FC = () => {
 			}
 
 			setForm(validatedForm);
+
+			if (!validForm) {
+				setPopupState("invalid");
+			} else {
+				setPopupState(null);
+			}
+
 			setFormIsValid(validForm);
 		}
 	};
 
-	const handleInputBlur = (
-		field: InputField,
-		section: string,
-		value: InputFieldValue,
-	): void => {
-		const { name, required } = field;
-
-		if (required) {
-			const validField = validateField(value);
-
-			const fields = [...form[section]];
-			const index = fields.findIndex(input => input.name === name);
-
-			fields[index] = { ...field, touched: true, valid: validField };
-
-			setForm({ ...form, [section]: fields });
-		}
-
-		validateForm();
-	};
-
 	const handleInputChange = (
 		field: InputField,
-		section: string,
 		value: InputFieldValue,
 	): void => {
 		if (nursingHome) {
-			const { name, type, touched } = field;
-
-			if (!touched) {
-				const fields = [...form[section]];
-				const index = fields.findIndex(input => input.name === name);
-
-				fields[index] = { ...field, touched: true };
-
-				setForm({ ...form, [section]: fields });
-			}
+			const { name, type } = field;
 
 			setNursingHome({
 				...nursingHome,
@@ -677,47 +698,53 @@ const PageUpdate: FC = () => {
 
 	const getInputElement = (
 		field: InputField,
-		section: string,
 		index: number,
 	): JSX.Element | null => {
 		if (nursingHome) {
 			const fieldInvalid =
 				field.required && field.touched && !field.valid;
+			const key = `${field.name}-${index}`;
 
 			switch (field.type) {
 				case "textarea":
 					return (
-						<div className="field" key={`${field.name}-${index}`}>
+						<div className="field" key={key}>
 							<label className="label" htmlFor={field.name}>
-								{field.label} {field.required ? "*" : ""}
+								{field.label}
+								{field.required ? (
+									<span
+										className="asterisk"
+										aria-hidden="true"
+									>
+										{" "}
+										*
+									</span>
+								) : null}
 							</label>
+							{field.description ? (
+								<span className="input-description">
+									{field.description}
+								</span>
+							) : null}
 							<div className="control">
 								<textarea
 									className={
 										fieldInvalid ? "input error" : "input"
 									}
 									rows={5}
-									value={
-										(nursingHome[field.name] as string) ||
-										""
-									}
+									maxLength={field.maxlength}
+									value={nursingHome[field.name] as string}
 									name={field.name}
 									id={field.name}
 									onChange={event =>
 										handleInputChange(
 											field,
-											section,
 											event.target.value,
 										)
 									}
 									required={field.required}
-									onBlur={event =>
-										handleInputBlur(
-											field,
-											section,
-											event.target.value,
-										)
-									}
+									aria-required={field.required}
+									onBlur={validateForm}
 								></textarea>
 								{fieldInvalid ? (
 									<span className="icon"></span>
@@ -730,12 +757,12 @@ const PageUpdate: FC = () => {
 					);
 				case "checkbox":
 					return (
-						<div className="field" key={`${field.name}-${index}`}>
+						<div className="field" key={key}>
 							<Checkbox
 								name={field.name}
 								id={field.name}
 								onChange={checked =>
-									handleInputChange(field, section, checked)
+									handleInputChange(field, checked)
 								}
 								isChecked={
 									(nursingHome[field.name] as boolean) ||
@@ -748,10 +775,7 @@ const PageUpdate: FC = () => {
 					);
 				case "radio":
 					return (
-						<fieldset
-							className="field"
-							key={`${field.name}-${index}`}
-						>
+						<fieldset className="field" key={key}>
 							<legend>{field.label}</legend>
 							{field.buttons
 								? field.buttons.map(button => {
@@ -776,7 +800,6 @@ const PageUpdate: FC = () => {
 
 													handleInputChange(
 														field,
-														section,
 														button.value,
 													);
 												}}
@@ -790,10 +813,24 @@ const PageUpdate: FC = () => {
 					);
 				default:
 					return (
-						<div className="field" key={`${field.name}-${index}`}>
+						<div className="field" key={key}>
 							<label className="label" htmlFor={field.name}>
-								{field.label} {field.required ? "*" : ""}
+								{field.label}
+								{field.required ? (
+									<span
+										className="asterisk"
+										aria-hidden="true"
+									>
+										{" "}
+										*
+									</span>
+								) : null}
 							</label>
+							{field.description ? (
+								<span className="input-description">
+									{field.description}
+								</span>
+							) : null}
 							<div className="control">
 								<input
 									className={
@@ -806,17 +843,12 @@ const PageUpdate: FC = () => {
 									onChange={event =>
 										handleInputChange(
 											field,
-											section,
 											event.target.value,
 										)
 									}
-									onBlur={event =>
-										handleInputBlur(
-											field,
-											section,
-											event.target.value,
-										)
-									}
+									onBlur={validateForm}
+									required={field.required}
+									aria-required={field.required}
 								/>
 								{fieldInvalid ? (
 									<span className="icon"></span>
@@ -835,6 +867,13 @@ const PageUpdate: FC = () => {
 
 	return (
 		<div className="page-update">
+			<p className="page-update-status">
+				<strong>{lastUpdate}: </strong>
+				{vacancyStatus
+					? formatDate(vacancyStatus.vacancy_last_updated_at) ||
+					  noUpdate
+					: loadingText}
+			</p>
 			<div className="page-update-content">
 				{!nursingHome ? (
 					<h1 className="page-update-title">{loadingText}</h1>
@@ -877,40 +916,11 @@ const PageUpdate: FC = () => {
 								)}
 							</div>
 							<div className="page-update-section">
-								<h3 className="page-update-minor-title">
-									{freeApartmentsStatus}
-								</h3>
-								<p className="page-update-data">
-									<strong>{nursingHomeName}: </strong>
-									{nursingHome.name}
-								</p>
-								<p className="page-update-data">
-									<strong>{status}: </strong>
-									{vacancyStatus
-										? vacancyStatus.has_vacancy
-											? labelTrue
-											: labelFalse
-										: loadingText}
-								</p>
-								<p className="page-update-data">
-									<strong>{lastUpdate}: </strong>
-									{vacancyStatus
-										? formatDate(
-												vacancyStatus.vacancy_last_updated_at,
-										  ) || noUpdate
-										: loadingText}
-								</p>
-
 								<div className="page-update-data">
 									{form.vacancyFields.map((field, index) =>
-										getInputElement(
-											field,
-											"vacancyFields",
-											index,
-										),
+										getInputElement(field, index),
 									)}
-								</div>
-								<div className="page-update-data">
+
 									<Link
 										className="btn update-images-button"
 										to={`/hoivakodit/${id}/paivita/${key}/kuvat`}
@@ -923,96 +933,60 @@ const PageUpdate: FC = () => {
 								<h3>{labelVisitingInfo}</h3>
 								{form.nursingHomeContactFields.map(
 									(field, index) =>
-										getInputElement(
-											field,
-											"nursingHomeContactFields",
-											index,
-										),
+										getInputElement(field, index),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelContactInfo}</h3>
 								<div className="page-update-columns">
 									{form.addressFields.map((field, index) =>
-										getInputElement(
-											field,
-											"addressFields",
-											index,
-										),
+										getInputElement(field, index),
 									)}
 								</div>
 								{form.contactFields.map((field, index) =>
-									getInputElement(
-										field,
-										"contactFields",
-										index,
-									),
+									getInputElement(field, index),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelBasicInformation}</h3>
 								{form.basicFields.map((field, index) =>
-									getInputElement(
-										field,
-										"basicFields",
-										index,
-									),
-								)}
-							</div>
-							<div className="page-update-section">
-								<h3>{labelNearbyServices}</h3>
-								{form.nearbyServicesFields.map((field, index) =>
-									getInputElement(
-										field,
-										"nearbyServicesFields",
-										index,
-									),
+									getInputElement(field, index),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelFoodHeader}</h3>
 								{form.foodFields.map((field, index) =>
-									getInputElement(field, "foodFields", index),
+									getInputElement(field, index),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelActivies}</h3>
 								{form.activitiesFields.map((field, index) =>
-									getInputElement(
-										field,
-										"activitiesFields",
-										index,
-									),
+									getInputElement(field, index),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelAccessibility}</h3>
 								{form.accessibilityFields.map((field, index) =>
-									getInputElement(
-										field,
-										"accessibilityFields",
-										index,
-									),
+									getInputElement(field, index),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelPersonnel}</h3>
 								{form.staffFields.map((field, index) =>
-									getInputElement(
-										field,
-										"staffFields",
-										index,
-									),
+									getInputElement(field, index),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelOtherServices}</h3>
 								{form.otherServicesFields.map((field, index) =>
-									getInputElement(
-										field,
-										"otherServicesFields",
-										index,
-									),
+									getInputElement(field, index),
+								)}
+							</div>
+							<div className="page-update-section">
+								<h3>{labelNearbyServices}</h3>
+								{form.nearbyServicesFields.map((field, index) =>
+									getInputElement(field, index),
 								)}
 							</div>
 						</form>

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -185,6 +185,7 @@ const PageUpdate: FC = () => {
 	const helperAccessibilityInfo = useT("helperAccessibilityInfo");
 	const helperStaffSatisfaction = useT("helperStaffSatisfaction");
 	const helperOtherServices = useT("helperOtherServices");
+	const helperUrl = useT("helperUrl");
 
 	const title = useT("updateNursingHomeTitle");
 	const freeApartmentsStatus = useT("freeApartmentsStatus");
@@ -355,6 +356,7 @@ const PageUpdate: FC = () => {
 				label: labelWebpage,
 				type: InputTypes.url,
 				name: "www",
+				description: helperUrl,
 				required: true,
 				valid: false,
 				touched: false,
@@ -516,6 +518,7 @@ const PageUpdate: FC = () => {
 				label: labelLinkMenu,
 				type: InputTypes.url,
 				name: "menu_link",
+				description: helperUrl,
 				required: true,
 				valid: false,
 				touched: false,
@@ -559,7 +562,7 @@ const PageUpdate: FC = () => {
 				label: labelLinkMoreActiviesInfo,
 				type: InputTypes.url,
 				name: "activities_link",
-				description: helperActivitiesLink,
+				description: `${helperActivitiesLink} ${helperUrl}`,
 			},
 			{
 				label: labelOutdoorActivies,
@@ -572,6 +575,7 @@ const PageUpdate: FC = () => {
 				label: labelLinkMoreOutdoorInfo,
 				type: InputTypes.url,
 				name: "outdoors_possibilities_link",
+				description: helperUrl,
 			},
 		],
 		accessibilityFields: [
@@ -595,7 +599,7 @@ const PageUpdate: FC = () => {
 				label: labelLinkMorePersonnelInfo,
 				type: InputTypes.url,
 				name: "staff_satisfaction_info",
-				description: helperStaffSatisfaction,
+				description: `${helperStaffSatisfaction} ${helperUrl}`,
 			},
 		],
 		otherServicesFields: [

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -136,7 +136,6 @@ const PageUpdate: FC = () => {
 	const labelPersonnel = useT("personnel");
 	const labelLinkMoreInfoPersonnel = useT("linkMoreInfoPersonnel");
 	const labelOtherServices = useT("otherServices");
-	const labelNearbyServices = useT("nearbyServices");
 	const labelBasicInformation = useT("basicInformation");
 	const labelContactInfo = useT("contactInfo");
 	const labelFoodHeader = useT("foodHeader");
@@ -162,10 +161,31 @@ const PageUpdate: FC = () => {
 	const labelContactDescription = useT("contactDescription");
 	const labelNursingHomeName = useT("nursingHomeName");
 	const labelSelectVancyStatus = useT("selectVancyStatus");
-	const title = useT("updateNursingHomeTitle");
-	const freeApartmentsStatus = useT("freeApartmentsStatus");
 	const labelTrue = useT("vacancyTrue");
 	const labelFalse = useT("vacancyFalse");
+	const labelPartlyARADestination = useT("partlyARADestination");
+	const labelFoodOwnKitchen = useT("foodOwnKitchen");
+	const labelFoodDelivered = useT("foodDelivered");
+	const labelActivitiesInfo = useT("activitiesInfo");
+	const labelStaffInfo = useT("staffInfo");
+	const labelNearbyServices = useT("labelNearbyServices");
+	const labelAddImages = useT("labelAddImages");
+
+	const helperSummary = useT("helperSummary");
+	const helperBuildingInfo = useT("helperBuildingInfo");
+	const helperApartmentCountInfo = useT("helperApartmentCountInfo");
+	const helperApartmentSize = useT("helperApartmentSize");
+	const helperRent = useT("helperRent");
+	const helperRentInfo = useT("helperRentInfo");
+	const helperLanguage = useT("helperLanguage");
+	const helperActivitiesLink = useT("helperActivitiesLink");
+	const helperOutdoorActivities = useT("helperOutdoorActivities");
+	const helperAccessibilityInfo = useT("helperAccessibilityInfo");
+	const helperStaffSatisfaction = useT("helperStaffSatisfaction");
+	const helperOtherServices = useT("helperOtherServices");
+
+	const title = useT("updateNursingHomeTitle");
+	const freeApartmentsStatus = useT("freeApartmentsStatus");
 	const loadingText = useT("loadingText");
 	const lastUpdate = useT("lastUpdate");
 	const noUpdate = useT("noUpdate");
@@ -175,6 +195,9 @@ const PageUpdate: FC = () => {
 	const updatePopupSaved = useT("saved");
 	const updatePopupSaving = useT("saving");
 	const formIsInvalid = useT("formIsInvalid");
+	const filterFinnish = useT("filterFinnish");
+	const filterSwedish = useT("filterSwedish");
+	const nearbyServices = useT("nearbyServices");
 
 	if (!id || !key) throw new Error("Invalid URL!");
 
@@ -210,150 +233,36 @@ const PageUpdate: FC = () => {
 	}, [id, key, popupState, vacancyStatus]);
 
 	const [form, setForm] = useState<{ [key: string]: InputField[] }>({
-		basicFields: [
+		vacancyFields: [
 			{
-				label: labelSummary,
-				type: InputTypes.textarea,
-				name: "summary",
-				description: "Hoivakodin palvelulupaus",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelOwner,
+				label: labelNursingHomeName,
 				type: InputTypes.text,
-				name: "owner",
+				name: "name",
 				required: true,
 				valid: false,
 				touched: false,
 			},
 			{
-				label: labelAra,
+				label: labelSelectVancyStatus,
 				type: InputTypes.radio,
-				name: "ara",
 				buttons: [
-					{ value: labelYes, label: labelYes },
-					{ value: labelNo, label: labelNo },
-					{
-						value: "Osa paikoista ARA-talossa",
-						label: "Osa paikoista ARA-talossa",
-					},
+					{ value: true, label: labelTrue },
+					{ value: false, label: labelFalse },
 				],
-			},
-			{
-				label: labelYearofConst,
-				type: InputTypes.number,
-				name: "construction_year",
+				name: "has_vacancy",
 				required: true,
 				valid: false,
 				touched: false,
-			},
-			{
-				label: labelBuildingInfo,
-				type: InputTypes.textarea,
-				name: "building_info",
-				description:
-					"Tässä voit kertoa mahdollisista tehdyistä tai tulossa olevista peruskorjauksista, laajennuksista jne.",
-				maxlength: 200,
-			},
-			{
-				label: labelNumApartments,
-				type: InputTypes.number,
-				name: "apartment_count",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelApartmentCountInfo,
-				type: InputTypes.textarea,
-				name: "apartment_count_info",
-				description:
-					"Tässä voit kertoa esim. minkä kokoisiin ryhmäkoteihin hoivakoti jakaantuu ja kuinka monta asuntoa on per kerros.",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelApartmentSize + " (m²)",
-				type: InputTypes.text,
-				name: "apartment_square_meters",
-				description: "Esim. 18-25",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelApartmentsHaveBathroom,
-				type: InputTypes.checkbox,
-				name: "apartments_have_bathroom",
-			},
-			{
-				label: labelRent + " (€ / kk)",
-				type: InputTypes.text,
-				name: "rent",
-				description: "Esim. 700-800",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelRentInfo,
-				type: InputTypes.textarea,
-				name: "rent_info",
-				description: "Mitä yhteisiä tiloja asiakkaan vuokraan sisältyy",
-			},
-			{
-				label: labelServiceLanguage,
-				type: InputTypes.checkbox,
-				name: "language",
-				buttons: [
-					{ label: "Suomi", value: "Suomi" },
-					{ label: "Ruotsi", value: "Ruotsi" },
-				],
-				change: (currentValue: any, buttonValue: string) => {
-					const valArray: Array<string> = currentValue
-						.split("|")
-						.filter((value: string) => value !== "");
+				change: (selected: InputFieldValue) => {
+					setHasVacancy(selected as boolean);
 
-					let newValue;
-
-					if (valArray.includes(buttonValue)) {
-						const itemIndex = valArray.indexOf(buttonValue);
-
-						valArray.splice(itemIndex, 1);
-					} else {
-						valArray.push(buttonValue);
-					}
-
-					const sortArray = valArray.sort((a, b) => {
-						return a.localeCompare(b);
-					});
-
-					if (sortArray.length > 1) {
-						newValue = sortArray.join("|");
-					} else if (sortArray.length === 1) {
-						newValue = sortArray[0];
-					} else {
-						newValue = "";
-					}
-
-					console.log(newValue);
-
-					return newValue;
+					return selected;
 				},
-				required: true,
-				valid: false,
-				touched: false,
 			},
 			{
-				label: labelLanguageInfo,
-				type: InputTypes.textarea,
-				name: "language_info",
-				description:
-					"Esim. lisätietoa henkilökunnan muusta kielitaidosta.",
-				maxlength: 200,
+				label: labelHasLAHapartments,
+				type: InputTypes.checkbox,
+				name: "lah",
 			},
 		],
 		addressFields: [
@@ -412,73 +321,6 @@ const PageUpdate: FC = () => {
 				maxlength: 200,
 			},
 		],
-		foodFields: [
-			{
-				label: labelLinkMenu,
-				type: InputTypes.url,
-				name: "menu_link",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelCookingMethod,
-				type: InputTypes.text,
-				name: "meals_preparation",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelFoodMoreInfo,
-				type: InputTypes.textarea,
-				name: "meals_info",
-				maxlength: 200,
-				description:
-					"Tässä voi halutessasi antaa lisätietoja ruuan valmistukseen ja ruokailuun liittyen.",
-			},
-		],
-		activitiesFields: [
-			{
-				label: labelActivies,
-				type: InputTypes.textarea,
-				name: "activities_info",
-				required: true,
-				valid: false,
-				touched: false,
-				description:
-					"Kuvaus hoivakodissa järjestettävästä toiminnasta.",
-				maxlength: 400,
-			},
-			{
-				label: labelLinkMoreInfoActivies,
-				type: InputTypes.url,
-				name: "activities_link",
-				description:
-					"Jos hoivakodin sivuilla on esim. ulkoilukalenteri, laita sen linkki tähän.",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelOutdoorActivies,
-				type: InputTypes.textarea,
-				name: "outdoors_possibilities_info",
-				description:
-					"Kuvaa hoivakodin ulkoilumahdollisuuksia. Kuvaile esim. miten ulkoilua järjestetään ja miten asiakkaat ulkoilevat.",
-				maxlength: 200,
-			},
-			{
-				label: labelLinkMoreInfoOutdoor,
-				type: InputTypes.url,
-				name: "outdoors_possibilities_link",
-				description:
-					"Jos hoivakodin sivuilla on esim. ulkoilukalenteri, laita se tähän.",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-		],
 		nursingHomeContactFields: [
 			{
 				label: labelContactDescription,
@@ -527,31 +369,244 @@ const PageUpdate: FC = () => {
 				maxlength: 200,
 			},
 		],
+		basicFields: [
+			{
+				label: labelSummary,
+				type: InputTypes.textarea,
+				name: "summary",
+				description: helperSummary,
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelOwner,
+				type: InputTypes.text,
+				name: "owner",
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelAra,
+				type: InputTypes.radio,
+				name: "ara",
+				buttons: [
+					{ value: labelYes, label: labelYes },
+					{ value: labelNo, label: labelNo },
+					{
+						value: labelPartlyARADestination,
+						label: labelPartlyARADestination,
+					},
+				],
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelYearofConst,
+				type: InputTypes.number,
+				name: "construction_year",
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelBuildingInfo,
+				type: InputTypes.textarea,
+				name: "building_info",
+				description: helperBuildingInfo,
+				maxlength: 200,
+			},
+			{
+				label: labelNumApartments,
+				type: InputTypes.number,
+				name: "apartment_count",
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelApartmentCountInfo,
+				type: InputTypes.textarea,
+				name: "apartment_count_info",
+				description: helperApartmentCountInfo,
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelApartmentSize + " (m²)",
+				type: InputTypes.text,
+				name: "apartment_square_meters",
+				description: helperApartmentSize,
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelApartmentsHaveBathroom,
+				type: InputTypes.checkbox,
+				name: "apartments_have_bathroom",
+			},
+			{
+				label: labelRent + " (€ / kk)",
+				type: InputTypes.text,
+				name: "rent",
+				description: helperRent,
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelRentInfo,
+				type: InputTypes.textarea,
+				name: "rent_info",
+				description: helperRentInfo,
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelServiceLanguage,
+				type: InputTypes.checkbox,
+				name: "language",
+				buttons: [
+					{ label: filterFinnish, value: filterFinnish },
+					{ label: filterSwedish, value: filterSwedish },
+				],
+				change: (currentValue: string, buttonValue: string) => {
+					const valArray: Array<string> = currentValue
+						.split("|")
+						.filter((value: string) => value !== "");
+
+					let newValue;
+
+					if (valArray.includes(buttonValue)) {
+						const itemIndex = valArray.indexOf(buttonValue);
+
+						valArray.splice(itemIndex, 1);
+					} else {
+						valArray.push(buttonValue);
+					}
+
+					const sortArray = valArray.sort((a, b) => {
+						return a.localeCompare(b);
+					});
+
+					if (sortArray.length > 1) {
+						newValue = sortArray.join("|");
+					} else if (sortArray.length === 1) {
+						newValue = sortArray[0];
+					} else {
+						newValue = "";
+					}
+
+					return newValue;
+				},
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelLanguageInfo,
+				type: InputTypes.textarea,
+				name: "language_info",
+				description: helperLanguage,
+				maxlength: 200,
+			},
+		],
+		foodFields: [
+			{
+				label: labelLinkMenu,
+				type: InputTypes.url,
+				name: "menu_link",
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelCookingMethod,
+				type: InputTypes.radio,
+				name: "meals_preparation",
+				buttons: [
+					{
+						value: labelFoodOwnKitchen,
+						label: labelFoodOwnKitchen,
+					},
+					{
+						value: labelFoodDelivered,
+						label: labelFoodDelivered,
+					},
+				],
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelFoodMoreInfo,
+				type: InputTypes.textarea,
+				name: "meals_info",
+				maxlength: 200,
+			},
+		],
+		activitiesFields: [
+			{
+				label: labelActivitiesInfo,
+				type: InputTypes.textarea,
+				name: "activities_info",
+				maxlength: 400,
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelLinkMoreInfoActivies,
+				type: InputTypes.url,
+				name: "activities_link",
+				description: helperActivitiesLink,
+				required: true,
+				valid: false,
+				touched: false,
+			},
+			{
+				label: labelOutdoorActivies,
+				type: InputTypes.textarea,
+				name: "outdoors_possibilities_info",
+				description: helperOutdoorActivities,
+				maxlength: 200,
+			},
+			{
+				label: labelLinkMoreInfoOutdoor,
+				type: InputTypes.url,
+				name: "outdoors_possibilities_link",
+				required: true,
+				valid: false,
+				touched: false,
+			},
+		],
 		accessibilityFields: [
 			{
 				label: labelAccessibilityInfo,
 				type: InputTypes.textarea,
 				name: "accessibility_info",
-				description:
-					"Tähän voit tarvittaessa kirjoittaa esteettömyyttä koskevia lisätietoja.",
+				description: helperAccessibilityInfo,
 				maxlength: 200,
 			},
 		],
+
 		staffFields: [
 			{
-				label: labelPersonnel,
+				label: labelStaffInfo,
 				type: InputTypes.textarea,
 				name: "staff_info",
-				description:
-					"Kerro halutessasi henkilöstöstä, sen rakenteesta ja erityisosaamisesta",
 				maxlength: 400,
 			},
 			{
 				label: labelLinkMoreInfoPersonnel,
 				type: InputTypes.url,
 				name: "staff_satisfaction_info",
-				description:
-					"Lisää linkki jos hoivakodin sivuilla on tietoa henkilöstön tyytyväisyydestä (kyselyn tulokset tms.).",
+				description: helperStaffSatisfaction,
 			},
 		],
 		otherServicesFields: [
@@ -559,8 +614,7 @@ const PageUpdate: FC = () => {
 				label: labelOtherServices,
 				type: InputTypes.textarea,
 				name: "other_services",
-				description:
-					"Kuvaa tähän mitä muita palvelukonseptiin kuulumattomia palveluita on saatavilla. Kerro myös mistä niiden hinnat löytyvät.",
+				description: helperOtherServices,
 				maxlength: 200,
 			},
 		],
@@ -569,38 +623,7 @@ const PageUpdate: FC = () => {
 				label: labelNearbyServices,
 				type: InputTypes.textarea,
 				name: "nearby_services",
-				description:
-					"Mitä palveluita löytyy hoivakodin läheltä esim. kauppa, kirjasto, ravintola jne.",
 				maxlength: 200,
-			},
-		],
-		vacancyFields: [
-			{
-				label: labelNursingHomeName,
-				type: InputTypes.text,
-				name: "name",
-				required: true,
-				valid: false,
-				touched: false,
-			},
-			{
-				label: labelSelectVancyStatus,
-				type: InputTypes.radio,
-				buttons: [
-					{ value: true, label: labelTrue },
-					{ value: false, label: labelFalse },
-				],
-				name: "has_vacancy",
-				change: (selected: InputFieldValue) => {
-					setHasVacancy(selected as boolean);
-
-					return selected;
-				},
-			},
-			{
-				label: labelHasLAHapartments,
-				type: InputTypes.checkbox,
-				name: "lah",
 			},
 		],
 	});
@@ -717,10 +740,20 @@ const PageUpdate: FC = () => {
 
 	const handleInputChange = (
 		field: InputField,
+		section: string,
 		value: InputFieldValue,
 	): void => {
 		if (nursingHome) {
 			const { name, type } = field;
+
+			const fields = [...form[section]];
+			const index = fields.findIndex(input => input.name === name);
+
+			const validField = validateField(value);
+
+			fields[index] = { ...field, touched: true, valid: validField };
+
+			setForm({ ...form, [section]: fields });
 
 			setNursingHome({
 				...nursingHome,
@@ -730,12 +763,11 @@ const PageUpdate: FC = () => {
 						: value,
 			});
 		}
-
-		validateForm();
 	};
 
 	const getInputElement = (
 		field: InputField,
+		section: string,
 		index: number,
 	): JSX.Element | null => {
 		if (nursingHome) {
@@ -777,6 +809,7 @@ const PageUpdate: FC = () => {
 									onChange={event =>
 										handleInputChange(
 											field,
+											section,
 											event.target.value,
 										)
 									}
@@ -798,45 +831,63 @@ const PageUpdate: FC = () => {
 						<Fragment key={key}>
 							{field.buttons ? (
 								<fieldset className="field">
-									<legend>{field.label}</legend>
-									{field.buttons.map(button => {
-										return (
-											<Checkbox
-												key={`${field.name}-${button.value}`}
-												id={`${field.name}-${button.value}`}
-												name={field.name}
-												onChange={() => {
-													if (field.change) {
-														const transformValue = field.change(
-															nursingHome[
-																field.name
-															],
-															button.value,
-														);
+									<legend>
+										{field.label}
+										{field.required ? (
+											<span
+												className="asterisk"
+												aria-hidden="true"
+											>
+												{" "}
+												*
+											</span>
+										) : null}
+									</legend>
+									<div className="control">
+										{field.buttons.map(button => {
+											return (
+												<Checkbox
+													key={`${field.name}-${button.value}`}
+													id={`${field.name}-${button.value}`}
+													name={field.name}
+													onChange={() => {
+														let newValue = button.value as InputFieldValue;
+
+														if (field.change) {
+															newValue = field.change(
+																nursingHome[
+																	field.name
+																],
+																button.value,
+															);
+														}
 
 														handleInputChange(
 															field,
-															transformValue,
+															section,
+															newValue,
 														);
-													} else {
-														handleInputChange(
-															field,
-															button.value,
-														);
-													}
-												}}
-												isChecked={(
-													(nursingHome[
+													}}
+													onBlur={validateForm}
+													isChecked={(nursingHome[
 														field.name
-													] as string) || ""
-												).includes(
-													button.value as string,
-												)}
-											>
-												{button.value}
-											</Checkbox>
-										);
-									})}
+													] as string).includes(
+														button.value as string,
+													)}
+												>
+													{button.value}
+												</Checkbox>
+											);
+										})}
+										{fieldInvalid ? (
+											<span className="icon"></span>
+										) : null}
+									</div>
+									{fieldInvalid ? (
+										<p className="help">
+											{textFieldIsRequired}
+										</p>
+									) : null}
 								</fieldset>
 							) : (
 								<div className="field">
@@ -844,8 +895,13 @@ const PageUpdate: FC = () => {
 										name={field.name}
 										id={field.name}
 										onChange={checked =>
-											handleInputChange(field, checked)
+											handleInputChange(
+												field,
+												section,
+												checked,
+											)
 										}
+										onBlur={validateForm}
 										isChecked={
 											(nursingHome[
 												field.name
@@ -861,44 +917,69 @@ const PageUpdate: FC = () => {
 				case "radio":
 					return (
 						<fieldset className="field" key={key}>
-							<legend>{field.label}</legend>
-							{field.buttons
-								? field.buttons.map(button => {
-										return (
-											<Radio
-												key={`${field.name}-${button.value}`}
-												id={`${field.name}-${button.value}`}
-												name={field.name}
-												isSelected={
-													(nursingHome[
-														field.name
-													] as string) ===
-													button.value
-												}
-												value={button.value}
-												onChange={() => {
-													if (field.change) {
-														const transformValue = field.change(
-															button.value,
-														);
+							<legend>
+								{field.label}
+								{field.required ? (
+									<span
+										className="asterisk"
+										aria-hidden="true"
+									>
+										{" "}
+										*
+									</span>
+								) : null}
+							</legend>
+							{field.buttons ? (
+								<Fragment>
+									<div className="control">
+										{field.buttons.map(button => {
+											return (
+												<Radio
+													key={`${field.name}-${button.value}`}
+													id={`${field.name}-${button.value}`}
+													name={field.name}
+													isSelected={
+														(nursingHome[
+															field.name
+														] as string) ===
+														button.value
+													}
+													value={button.value}
+													onChange={() => {
+														let newValue = button.value as InputFieldValue;
+
+														if (field.change) {
+															newValue = field.change(
+																nursingHome[
+																	field.name
+																],
+																button.value,
+															);
+														}
 
 														handleInputChange(
 															field,
-															transformValue,
+															section,
+															newValue,
 														);
-													} else {
-														handleInputChange(
-															field,
-															button.value,
-														);
-													}
-												}}
-											>
-												{button.label}
-											</Radio>
-										);
-								  })
-								: null}
+													}}
+													onBlur={validateForm}
+												>
+													{button.label}
+												</Radio>
+											);
+										})}
+										{fieldInvalid ? (
+											<span className="icon"></span>
+										) : null}
+									</div>
+									{fieldInvalid ? (
+										<p className="help">
+											{textFieldIsRequired}
+										</p>
+									) : null}
+								</Fragment>
+							) : null}
 						</fieldset>
 					);
 				default:
@@ -933,6 +1014,7 @@ const PageUpdate: FC = () => {
 									onChange={event =>
 										handleInputChange(
 											field,
+											section,
 											event.target.value,
 										)
 									}
@@ -1008,74 +1090,114 @@ const PageUpdate: FC = () => {
 							<div className="page-update-section">
 								<h3>{freeApartmentsStatus}</h3>
 								{form.vacancyFields.map((field, index) =>
-									getInputElement(field, index),
+									getInputElement(
+										field,
+										"vacancyFields",
+										index,
+									),
 								)}
 
 								<Link
 									className="btn update-images-button"
 									to={`/hoivakodit/${id}/paivita/${key}/kuvat`}
 								>
-									Lisää kuvia
+									{labelAddImages}
 								</Link>
 							</div>
 							<div className="page-update-section">
 								<h3>{labelVisitingInfo}</h3>
 								{form.nursingHomeContactFields.map(
 									(field, index) =>
-										getInputElement(field, index),
+										getInputElement(
+											field,
+											"nursingHomeContactFields",
+											index,
+										),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelContactInfo}</h3>
 								<div className="page-update-columns">
 									{form.addressFields.map((field, index) =>
-										getInputElement(field, index),
+										getInputElement(
+											field,
+											"addressFields",
+											index,
+										),
 									)}
 								</div>
 								{form.contactFields.map((field, index) =>
-									getInputElement(field, index),
+									getInputElement(
+										field,
+										"contactFields",
+										index,
+									),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelBasicInformation}</h3>
 								{form.basicFields.map((field, index) =>
-									getInputElement(field, index),
+									getInputElement(
+										field,
+										"basicFields",
+										index,
+									),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelFoodHeader}</h3>
 								{form.foodFields.map((field, index) =>
-									getInputElement(field, index),
+									getInputElement(field, "foodFields", index),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelActivies}</h3>
 								{form.activitiesFields.map((field, index) =>
-									getInputElement(field, index),
+									getInputElement(
+										field,
+										"activitiesFields",
+										index,
+									),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelAccessibility}</h3>
 								{form.accessibilityFields.map((field, index) =>
-									getInputElement(field, index),
+									getInputElement(
+										field,
+										"accessibilityFields",
+										index,
+									),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelPersonnel}</h3>
 								{form.staffFields.map((field, index) =>
-									getInputElement(field, index),
+									getInputElement(
+										field,
+										"staffFields",
+										index,
+									),
 								)}
 							</div>
 							<div className="page-update-section">
 								<h3>{labelOtherServices}</h3>
 								{form.otherServicesFields.map((field, index) =>
-									getInputElement(field, index),
+									getInputElement(
+										field,
+										"otherServicesFields",
+										index,
+									),
 								)}
 							</div>
 							<div className="page-update-section">
-								<h3>{labelNearbyServices}</h3>
+								<h3>{nearbyServices}</h3>
 								{form.nearbyServicesFields.map((field, index) =>
-									getInputElement(field, index),
+									getInputElement(
+										field,
+										"nearbyServicesFields",
+										index,
+									),
 								)}
 							</div>
 						</form>

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -682,10 +682,7 @@ const PageUpdate: FC = () => {
 	const getInputElement = (field: InputField, index: number): JSX.Element => {
 		if (field.type === "textarea") {
 			return (
-				<div
-					className="page-update-input"
-					key={`${field.name}-${index}`}
-				>
+				<div className="field" key={`${field.name}-${index}`}>
 					<label htmlFor={field.name}>{field.label}</label>
 					<div className="control">
 						<textarea
@@ -707,7 +704,7 @@ const PageUpdate: FC = () => {
 							}
 						></textarea>
 						{field.required && formErrors[field.name] ? (
-							<span className="page-update-input-error">
+							<span className="field-error">
 								{textFieldIsRequired}
 							</span>
 						) : null}
@@ -716,10 +713,7 @@ const PageUpdate: FC = () => {
 			);
 		} else if (field.type === "checkbox") {
 			return (
-				<div
-					className="page-update-input"
-					key={`${field.name}-${index}`}
-				>
+				<div className="field" key={`${field.name}-${index}`}>
 					<Checkbox
 						name={field.name}
 						id={field.name}
@@ -732,10 +726,7 @@ const PageUpdate: FC = () => {
 			);
 		} else if (field.type === "radio") {
 			return (
-				<fieldset
-					className="page-update-input"
-					key={`${field.name}-${index}`}
-				>
+				<fieldset className="field" key={`${field.name}-${index}`}>
 					<legend>{labelAra}</legend>
 					{field.buttons
 						? field.buttons.map(button => {
@@ -766,10 +757,7 @@ const PageUpdate: FC = () => {
 			);
 		} else {
 			return (
-				<div
-					className="page-update-input"
-					key={`${field.name}-${index}`}
-				>
+				<div className="field" key={`${field.name}-${index}`}>
 					<label htmlFor={field.name}>{field.label}</label>
 					<div className="control">
 						<input
@@ -790,7 +778,7 @@ const PageUpdate: FC = () => {
 							}
 						/>
 						{field.required && formErrors[field.name] ? (
-							<span className="page-update-input-error">
+							<span className="field-error">
 								{textFieldIsRequired}
 							</span>
 						) : null}

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -39,6 +39,7 @@ interface InputField {
 	name: NursingHomeKey;
 	buttons?: { value: string; label: string }[];
 	required?: boolean;
+	valid?: boolean;
 }
 
 type TransformableNursingHome = OptionalProps<
@@ -131,9 +132,9 @@ const PageUpdate: FC = () => {
 	>(null);
 	const [hasVacancy, setHasVacancy] = useState<boolean>(false);
 
-	const [formErrors, setFormErrors] = useState<{ [key: string]: boolean }>(
-		{},
-	);
+	// const [formErrors, setFormErrors] = useState<{ [key: string]: boolean }>(
+	// 	{},
+	// );
 
 	if (!id || !key) throw new Error("Invalid URL!");
 
@@ -259,29 +260,21 @@ const PageUpdate: FC = () => {
 	const updatePopupSaving = useT("saving");
 	const formIsInvalid = useT("formIsInvalid");
 
-	let basicFields: InputField[] = [];
-	let contactFields: InputField[] = [];
-	let foodFields: InputField[] = [];
-	let activitiesFields: InputField[] = [];
-	let nursingHomeContactFields: InputField[] = [];
-	let accessibilityFields: InputField[] = [];
-	let staffFields: InputField[] = [];
-	let otherServicesFields: InputField[] = [];
-	let nearbyServicesFields: InputField[] = [];
-
-	if (nursingHome) {
-		basicFields = [
+	const [form, setForm] = useState<{ [key: string]: InputField[] }>({
+		basicFields: [
 			{
 				label: labelSummary,
 				type: InputTypes.textarea,
 				name: "summary",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelOwner,
 				type: InputTypes.text,
 				name: "owner",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelAra,
@@ -298,6 +291,7 @@ const PageUpdate: FC = () => {
 				type: InputTypes.number,
 				name: "construction_year",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelBuildingInfo,
@@ -309,6 +303,7 @@ const PageUpdate: FC = () => {
 				type: InputTypes.number,
 				name: "apartment_count",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelApartmentCountInfo,
@@ -320,6 +315,7 @@ const PageUpdate: FC = () => {
 				type: InputTypes.text,
 				name: "apartment_square_meters",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelApartmentsHaveBathroom,
@@ -331,6 +327,7 @@ const PageUpdate: FC = () => {
 				type: InputTypes.text,
 				name: "rent",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelRentInfo,
@@ -342,6 +339,7 @@ const PageUpdate: FC = () => {
 				type: InputTypes.text,
 				name: "language",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelLanguageInfo,
@@ -353,26 +351,28 @@ const PageUpdate: FC = () => {
 				type: InputTypes.checkbox,
 				name: "lah",
 			},
-		];
-
-		contactFields = [
+		],
+		contactFields: [
 			{
 				label: labelAddress,
 				type: InputTypes.text,
 				name: "address",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelPostalCode,
 				type: InputTypes.text,
 				name: "postal_code",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelCity,
 				type: InputTypes.text,
 				name: "city",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelDistrict,
@@ -394,14 +394,14 @@ const PageUpdate: FC = () => {
 				type: InputTypes.textarea,
 				name: "arrival_guide_car",
 			},
-		];
-
-		foodFields = [
+		],
+		foodFields: [
 			{
 				label: labelCookingMethod,
 				type: InputTypes.text,
 				name: "meals_preparation",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelFoodMoreInfo,
@@ -413,9 +413,8 @@ const PageUpdate: FC = () => {
 				type: InputTypes.url,
 				name: "menu_link",
 			},
-		];
-
-		activitiesFields = [
+		],
+		activitiesFields: [
 			{
 				label: labelActivies,
 				type: InputTypes.textarea,
@@ -436,9 +435,8 @@ const PageUpdate: FC = () => {
 				type: InputTypes.url,
 				name: "outdoors_possibilities_link",
 			},
-		];
-
-		nursingHomeContactFields = [
+		],
+		nursingHomeContactFields: [
 			{
 				label: labelVisitingInfo,
 				type: InputTypes.textarea,
@@ -449,41 +447,43 @@ const PageUpdate: FC = () => {
 				type: InputTypes.text,
 				name: "contact_name",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelContactTitle,
 				type: InputTypes.text,
 				name: "contact_title",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelContactPhone,
 				type: InputTypes.tel,
 				name: "contact_phone",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelContactEmail,
 				type: InputTypes.email,
 				name: "email",
 				required: true,
+				valid: true,
 			},
 			{
 				label: labelContactPhoneInfo,
 				type: InputTypes.textarea,
 				name: "contact_phone_info",
 			},
-		];
-
-		accessibilityFields = [
+		],
+		accessibilityFields: [
 			{
 				label: labelAccessibility,
 				type: InputTypes.textarea,
 				name: "accessibility_info",
 			},
-		];
-
-		staffFields = [
+		],
+		staffFields: [
 			{
 				label: labelPersonnel,
 				type: InputTypes.textarea,
@@ -494,24 +494,22 @@ const PageUpdate: FC = () => {
 				type: InputTypes.url,
 				name: "staff_satisfaction_info",
 			},
-		];
-
-		otherServicesFields = [
+		],
+		otherServicesFields: [
 			{
 				label: labelOtherServices,
 				type: InputTypes.textarea,
 				name: "other_services",
 			},
-		];
-
-		nearbyServicesFields = [
+		],
+		nearbyServicesFields: [
 			{
 				label: labelNearbyServices,
 				type: InputTypes.textarea,
 				name: "nearby_services",
 			},
-		];
-	}
+		],
+	});
 
 	const removeImage = (id: string): void => {
 		const index = imageState.findIndex(x => x.name === id);
@@ -531,16 +529,20 @@ const PageUpdate: FC = () => {
 	};
 
 	const validForm = (): boolean => {
-		const formInvalid =
-			Object.keys(formErrors).map(field => formErrors[field]).length > 0;
+		let formIsValid = true;
 
-		if (formInvalid) {
-			setPopupState("invalid");
+		Object.keys(form).forEach(section => {
+			const invalidFields =
+				form[section].filter(field => {
+					return field.valid === false;
+				}).length > 0;
 
-			return false;
-		} else {
-			return true;
-		}
+			if (invalidFields) {
+				formIsValid = false;
+			}
+		});
+
+		return formIsValid;
 	};
 
 	const handleSubmit = async (
@@ -584,6 +586,8 @@ const PageUpdate: FC = () => {
 
 				setPopupState("saved");
 				setVacancyStatus(null);
+			} else {
+				setPopupState("invalid");
 			}
 		} catch (error) {
 			console.error(error);
@@ -602,26 +606,42 @@ const PageUpdate: FC = () => {
 
 	const handleInputBlur = (
 		field: InputField,
+		section: string,
 		value: string | number,
 	): void => {
-		if (nursingHome) {
-			const { name, required } = field;
+		const { name, required } = field;
 
-			if (required) {
-				const fieldIsValid = validateField(value);
+		if (required) {
+			const fieldIsValid = validateField(value);
+			let updatedSection;
 
-				if (!fieldIsValid) {
-					setFormErrors({
-						...formErrors,
-						[name]: true,
-					});
-				} else {
-					const newErrors = { ...formErrors };
-					delete newErrors[name];
+			if (!fieldIsValid) {
+				updatedSection = [...form[section]].map(input => {
+					if (input.name === name) {
+						return {
+							...input,
+							valid: false,
+						};
+					}
 
-					setFormErrors(newErrors);
-				}
+					return input;
+				});
+
+				setForm({ ...form, [section]: updatedSection });
+			} else {
+				updatedSection = [...form[section]].map(input => {
+					if (input.name === name) {
+						return {
+							...input,
+							valid: true,
+						};
+					}
+
+					return input;
+				});
 			}
+
+			setForm({ ...form, [section]: updatedSection });
 		}
 	};
 
@@ -644,6 +664,7 @@ const PageUpdate: FC = () => {
 
 	const getInputElement = (
 		field: InputField,
+		section: string,
 		index: number,
 	): JSX.Element | null => {
 		if (nursingHome) {
@@ -654,7 +675,7 @@ const PageUpdate: FC = () => {
 						<div className="control">
 							<textarea
 								className={
-									field.required && formErrors[field.name]
+									field.required && !field.valid
 										? "error"
 										: ""
 								}
@@ -669,14 +690,18 @@ const PageUpdate: FC = () => {
 								}
 								required={field.required}
 								onBlur={event =>
-									handleInputBlur(field, event.target.value)
+									handleInputBlur(
+										field,
+										section,
+										event.target.value,
+									)
 								}
 							></textarea>
-							{field.required && formErrors[field.name] ? (
+							{field.required && !field.valid ? (
 								<span className="icon"></span>
 							) : null}
 						</div>
-						{field.required && formErrors[field.name] ? (
+						{field.required && !field.valid ? (
 							<p className="help">{textFieldIsRequired}</p>
 						) : null}
 					</div>
@@ -738,7 +763,7 @@ const PageUpdate: FC = () => {
 						<div className="control">
 							<input
 								className={
-									field.required && formErrors[field.name]
+									field.required && !field.valid
 										? "error"
 										: ""
 								}
@@ -750,14 +775,18 @@ const PageUpdate: FC = () => {
 									handleInputChange(field, event.target.value)
 								}
 								onBlur={event =>
-									handleInputBlur(field, event.target.value)
+									handleInputBlur(
+										field,
+										section,
+										event.target.value,
+									)
 								}
 							/>
-							{field.required && formErrors[field.name] ? (
+							{field.required && !field.valid ? (
 								<span className="icon"></span>
 							) : null}
 						</div>
-						{field.required && formErrors[field.name] ? (
+						{field.required && !field.valid ? (
 							<p className="help">{textFieldIsRequired}</p>
 						) : null}
 					</div>
@@ -910,56 +939,76 @@ const PageUpdate: FC = () => {
 						</div>
 						<div className="page-update-section">
 							<h3>{labelBasicInformation}</h3>
-							{basicFields.map((field, index) =>
-								getInputElement(field, index),
+							{form.basicFields.map((field, index) =>
+								getInputElement(field, "basicFields", index),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>{labelContactInfo}</h3>
-							{contactFields.map((field, index) =>
-								getInputElement(field, index),
+							{form.contactFields.map((field, index) =>
+								getInputElement(field, "contactFields", index),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>{labelFoodHeader}</h3>
-							{foodFields.map((field, index) =>
-								getInputElement(field, index),
+							{form.foodFields.map((field, index) =>
+								getInputElement(field, "foodFields", index),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>{labelActivies}</h3>
-							{activitiesFields.map((field, index) =>
-								getInputElement(field, index),
+							{form.activitiesFields.map((field, index) =>
+								getInputElement(
+									field,
+									"activitiesFields",
+									index,
+								),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>{labelVisitingInfo}</h3>
-							{nursingHomeContactFields.map((field, index) =>
-								getInputElement(field, index),
+							{form.nursingHomeContactFields.map((field, index) =>
+								getInputElement(
+									field,
+									"nursingHomeContactFields",
+									index,
+								),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>{labelAccessibility}</h3>
-							{accessibilityFields.map((field, index) =>
-								getInputElement(field, index),
+							{form.accessibilityFields.map((field, index) =>
+								getInputElement(
+									field,
+									"accessibilityFields",
+									index,
+								),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>{labelPersonnel}</h3>
-							{staffFields.map((field, index) =>
-								getInputElement(field, index),
+							{form.staffFields.map((field, index) =>
+								getInputElement(field, "staffFields", index),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>{labelOtherServices}</h3>
-							{otherServicesFields.map((field, index) =>
-								getInputElement(field, index),
+							{form.otherServicesFields.map((field, index) =>
+								getInputElement(
+									field,
+									"otherServicesFields",
+									index,
+								),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>{labelNearbyServices}</h3>
-							{nearbyServicesFields.map((field, index) =>
-								getInputElement(field, index),
+							{form.nearbyServicesFields.map((field, index) =>
+								getInputElement(
+									field,
+									"nearbyServicesFields",
+									index,
+								),
 							)}
 						</div>
 					</>

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -475,34 +475,30 @@ const PageUpdate: FC = () => {
 					{ label: filterFinnish, value: filterFinnish },
 					{ label: filterSwedish, value: filterSwedish },
 				],
-				change: (currentValue: string, buttonValue: string) => {
-					const valArray: Array<string> = currentValue
+				change: (current: string, value: string) => {
+					const languages: string[] = current
 						.split("|")
 						.filter((value: string) => value !== "");
 
-					let newValue;
+					if (languages.includes(value)) {
+						const index = languages.indexOf(value);
 
-					if (valArray.includes(buttonValue)) {
-						const itemIndex = valArray.indexOf(buttonValue);
-
-						valArray.splice(itemIndex, 1);
+						languages.splice(index, 1);
 					} else {
-						valArray.push(buttonValue);
+						languages.push(value);
 					}
 
-					const sortArray = valArray.sort((a, b) => {
+					const sortLanguages = languages.sort((a, b) => {
 						return a.localeCompare(b);
 					});
 
-					if (sortArray.length > 1) {
-						newValue = sortArray.join("|");
-					} else if (sortArray.length === 1) {
-						newValue = sortArray[0];
+					if (sortLanguages.length > 1) {
+						return sortLanguages.join("|");
+					} else if (sortLanguages.length === 1) {
+						return sortLanguages[0];
 					} else {
-						newValue = "";
+						return "";
 					}
-
-					return newValue;
 				},
 				required: true,
 				valid: false,
@@ -727,14 +723,13 @@ const PageUpdate: FC = () => {
 			}
 
 			setForm(validatedForm);
+			setFormIsValid(validForm);
 
 			if (!validForm) {
 				setPopupState("invalid");
 			} else {
 				setPopupState(null);
 			}
-
-			setFormIsValid(validForm);
 		}
 	};
 

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -21,6 +21,21 @@ enum InputTypes {
 	radio = "radio",
 }
 
+type NursingHomeKey = keyof NursingHome;
+
+type NursingHomeUpdateData = Omit<
+	NursingHome,
+	| "id"
+	| "pic_digests"
+	| "pics"
+	| "pic_captions"
+	| "report_status"
+	| "rating"
+	| "geolocation"
+	| "has_vacancy"
+	| "basic_update_key"
+>;
+
 interface VacancyStatus {
 	has_vacancy: boolean;
 	vacancy_last_updated_at: string | null;
@@ -39,21 +54,6 @@ interface InputField {
 	required?: boolean;
 	valid?: boolean;
 }
-
-type NursingHomeKey = keyof NursingHome;
-
-type NursingHomeUpdateData = Omit<
-	NursingHome,
-	| "id"
-	| "pic_digests"
-	| "pics"
-	| "pic_captions"
-	| "report_status"
-	| "rating"
-	| "geolocation"
-	| "has_vacancy"
-	| "basic_update_key"
->;
 
 const formatDate = (dateString: string | null): string => {
 	if (!dateString) return "";
@@ -164,6 +164,25 @@ const PageUpdate: FC = () => {
 	const labelContactPhone = useT("contactPhone");
 	const labelContactEmail = useT("contactEmail");
 	const labelContactPhoneInfo = useT("contactPhoneInfo");
+	const title = useT("pageUpdateTitle");
+	const freeApartmentsStatus = useT("freeApartmentsStatus");
+	const organizationLogo = useT("organizationLogo");
+	const organizationPhotos = useT("organizationPhotos");
+	const organizationPhotosGuide = useT("organizationPhotosGuide");
+	const intro = useT("pageUpdateIntro");
+	const labelTrue = useT("vacancyTrue");
+	const labelFalse = useT("vacancyFalse");
+	const loadingText = useT("loadingText");
+	const nursingHomeName = useT("nursingHome");
+	const status = useT("status");
+	const lastUpdate = useT("lastUpdate");
+	const noUpdate = useT("noUpdate");
+	const btnSave = useT("btnSave");
+	const cancel = useT("cancel");
+	const textFieldIsRequired = useT("fieldIsRequired");
+	const updatePopupSaved = useT("saved");
+	const updatePopupSaving = useT("saving");
+	const formIsInvalid = useT("formIsInvalid");
 
 	const [form, setForm] = useState<{ [key: string]: InputField[] }>({
 		basicFields: [
@@ -474,26 +493,6 @@ const PageUpdate: FC = () => {
 		"nursinghome_layout",
 	];
 
-	const title = useT("pageUpdateTitle");
-	const freeApartmentsStatus = useT("freeApartmentsStatus");
-	const organizationLogo = useT("organizationLogo");
-	const organizationPhotos = useT("organizationPhotos");
-	const organizationPhotosGuide = useT("organizationPhotosGuide");
-	const intro = useT("pageUpdateIntro");
-	const labelTrue = useT("vacancyTrue");
-	const labelFalse = useT("vacancyFalse");
-	const loadingText = useT("loadingText");
-	const nursingHomeName = useT("nursingHome");
-	const status = useT("status");
-	const lastUpdate = useT("lastUpdate");
-	const noUpdate = useT("noUpdate");
-	const btnSave = useT("btnSave");
-	const cancel = useT("cancel");
-	const textFieldIsRequired = useT("fieldIsRequired");
-	const updatePopupSaved = useT("saved");
-	const updatePopupSaving = useT("saving");
-	const formIsInvalid = useT("formIsInvalid");
-
 	const removeImage = (id: string): void => {
 		const index = imageState.findIndex(x => x.name === id);
 		imageState[index].remove = true;
@@ -597,36 +596,12 @@ const PageUpdate: FC = () => {
 
 		if (required) {
 			const validField = validateField(value);
+			const fields = [...form[section]];
+			const index = fields.findIndex(input => input.name === name);
 
-			let updatedSection;
+			fields[index] = { ...field, valid: validField };
 
-			if (!validField) {
-				updatedSection = [...form[section]].map(input => {
-					if (input.name === name) {
-						return {
-							...input,
-							valid: false,
-						};
-					}
-
-					return input;
-				});
-
-				setForm({ ...form, [section]: updatedSection });
-			} else {
-				updatedSection = [...form[section]].map(input => {
-					if (input.name === name) {
-						return {
-							...input,
-							valid: true,
-						};
-					}
-
-					return input;
-				});
-			}
-
-			setForm({ ...form, [section]: updatedSection });
+			setForm({ ...form, [section]: fields });
 		}
 	};
 
@@ -737,13 +712,11 @@ const PageUpdate: FC = () => {
 													button.value
 												}
 												value={button.value}
-												onChange={isChecked => {
-													if (isChecked) {
-														handleInputChange(
-															field,
-															button.value,
-														);
-													}
+												onChange={() => {
+													handleInputChange(
+														field,
+														button.value,
+													);
 												}}
 											>
 												{button.label}

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -7,7 +7,7 @@ import { useParams } from "react-router-dom";
 import axios from "axios";
 import config from "./config";
 import { GetNursingHomeResponse } from "./PageNursingHome";
-import { NursingHome, NursingHomeImageName } from "./types";
+import { NursingHome, NursingHomeImageName, OptionalProps } from "./types";
 import Checkbox from "./Checkbox";
 
 enum InputTypes {
@@ -39,7 +39,6 @@ interface InputField {
 	buttons?: { value: string; label: string }[];
 }
 
-type OptionalProps<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 type TransformableNursingHome = OptionalProps<
 	NursingHome,
 	| "id"

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -55,8 +55,8 @@ const requestVacancyStatusUpdate = async (
 ): Promise<void> => {
 	await axios.post(
 		`${config.API_URL}/nursing-homes/${id}/vacancy-status/${key}`,
-		// eslint-disable-next-line @typescript-eslint/camelcase
 		{
+			// eslint-disable-next-line @typescript-eslint/camelcase
 			has_vacancy: status,
 		},
 	);
@@ -64,7 +64,6 @@ const requestVacancyStatusUpdate = async (
 	for (const image of images) {
 		await axios.post(
 			`${config.API_URL}/nursing-homes/${id}/update-image/${key}`,
-			// eslint-disable-next-line @typescript-eslint/camelcase
 			{
 				image: image,
 			},
@@ -463,19 +462,19 @@ const PageUpdate: FC = () => {
 		];
 	}
 
-	const removeImage = (id: string) => {
+	const removeImage = (id: string): void => {
 		const index = imageState.findIndex(x => x.name === id);
 		imageState[index].remove = true;
 		imageState[index].value = "";
 	};
 
-	const updateImageState = (id: string, state: string) => {
+	const updateImageState = (id: string, state: string): void => {
 		const index = imageState.findIndex(x => x.name === id);
 		imageState[index].value = state;
 		imageState[index].remove = false;
 	};
 
-	const updateCaptionState = (id: string, state: string) => {
+	const updateCaptionState = (id: string, state: string): void => {
 		const index = imageState.findIndex(x => x.name === id);
 		imageState[index].text = state;
 	};
@@ -501,7 +500,7 @@ const PageUpdate: FC = () => {
 			| React.ChangeEvent<HTMLInputElement>
 			| React.ChangeEvent<HTMLTextAreaElement>
 			| boolean,
-	) => {
+	): void => {
 		if (nursingHome) {
 			if (typeof data === "boolean") {
 				setNursingHome({ ...nursingHome, [key]: data });
@@ -544,9 +543,10 @@ const PageUpdate: FC = () => {
 						onChange={checked =>
 							handleInputChange(field.name, checked)
 						}
-						children={field.label}
 						isChecked={(field.value as boolean) || false}
-					/>
+					>
+						{field.label}
+					</Checkbox>
 				</div>
 			);
 		} else {

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -35,7 +35,6 @@ type NursingHomeUpdateData = Omit<
 	| "has_vacancy"
 	| "basic_update_key"
 >;
-
 interface VacancyStatus {
 	has_vacancy: boolean;
 	vacancy_last_updated_at: string | null;
@@ -55,7 +54,7 @@ interface InputField {
 	required?: boolean;
 	valid?: boolean;
 	touched?: boolean;
-	change?: (...arg: any) => InputFieldValue;
+	change?: (...arg: string[]) => InputFieldValue;
 	maxlength?: number;
 }
 
@@ -256,10 +255,10 @@ const PageUpdate: FC = () => {
 				required: true,
 				valid: false,
 				touched: false,
-				change: (selected: InputFieldValue) => {
-					setHasVacancy(selected as boolean);
+				change: (_, value: InputFieldValue) => {
+					setHasVacancy(value as boolean);
 
-					return selected;
+					return value;
 				},
 			},
 			{
@@ -659,13 +658,9 @@ const PageUpdate: FC = () => {
 						}
 					}
 
-					const updateNursingHomeData: NursingHomeUpdateData = formData;
+					const updateFormData: NursingHomeUpdateData = formData;
 
-					await requestNursingHomeUpdate(
-						id,
-						key,
-						updateNursingHomeData,
-					);
+					await requestNursingHomeUpdate(id, key, updateFormData);
 				}
 
 				setPopupState("saved");
@@ -867,8 +862,8 @@ const PageUpdate: FC = () => {
 															newValue = field.change(
 																nursingHome[
 																	field.name
-																],
-																button.value,
+																] as string,
+																button.value as string,
 															);
 														}
 
@@ -949,10 +944,9 @@ const PageUpdate: FC = () => {
 													id={`${field.name}-${button.value}`}
 													name={field.name}
 													isSelected={
-														(nursingHome[
+														nursingHome[
 															field.name
-														] as string) ===
-														button.value
+														] === button.value
 													}
 													value={button.value}
 													onChange={() => {
@@ -962,8 +956,8 @@ const PageUpdate: FC = () => {
 															newValue = field.change(
 																nursingHome[
 																	field.name
-																],
-																button.value,
+																] as string,
+																button.value as string,
 															);
 														}
 

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -31,11 +31,12 @@ interface NursingHomeRouteParams {
 	key: string;
 }
 
+type NursingHomeKey = keyof NursingHome;
+
 interface InputField {
 	label: string;
 	type: InputTypes;
-	name: string;
-	model: string | number | boolean | undefined;
+	name: NursingHomeKey;
 	buttons?: { value: string; label: string }[];
 	required?: boolean;
 }
@@ -274,21 +275,19 @@ const PageUpdate: FC = () => {
 				label: labelSummary,
 				type: InputTypes.textarea,
 				name: "summary",
-				model: nursingHome.summary,
 				required: true,
 			},
 			{
 				label: labelOwner,
 				type: InputTypes.text,
 				name: "owner",
-				model: nursingHome.owner,
 				required: true,
 			},
 			{
 				label: labelAra,
 				type: InputTypes.radio,
 				name: "ara",
-				model: nursingHome.ara,
+
 				buttons: [
 					{ value: labelYes, label: labelYes },
 					{ value: labelNo, label: labelNo },
@@ -298,72 +297,61 @@ const PageUpdate: FC = () => {
 				label: labelYearofConst,
 				type: InputTypes.number,
 				name: "construction_year",
-				model: nursingHome.construction_year,
 				required: true,
 			},
 			{
 				label: labelBuildingInfo,
 				type: InputTypes.textarea,
 				name: "building_info",
-				model: nursingHome.building_info,
 			},
 			{
 				label: labelNumApartments,
 				type: InputTypes.number,
 				name: "apartment_count",
-				model: nursingHome.apartment_count,
 				required: true,
 			},
 			{
 				label: labelApartmentCountInfo,
 				type: InputTypes.textarea,
 				name: "apartment_count_info",
-				model: nursingHome.apartment_count_info,
 			},
 			{
 				label: labelApartmentSize + " (m²)",
 				type: InputTypes.text,
 				name: "apartment_square_meters",
-				model: nursingHome.apartment_square_meters,
 				required: true,
 			},
 			{
 				label: labelApartmentsHaveBathroom,
 				type: InputTypes.checkbox,
 				name: "apartments_have_bathroom",
-				model: nursingHome.apartments_have_bathroom,
 			},
 			{
 				label: labelRent + " (€ / kk)",
 				type: InputTypes.text,
 				name: "rent",
-				model: nursingHome.rent,
 				required: true,
 			},
 			{
 				label: labelRentInfo,
 				type: InputTypes.textarea,
 				name: "rent_info",
-				model: nursingHome.rent_info,
 			},
 			{
 				label: labelServiceLanguage,
 				type: InputTypes.text,
 				name: "language",
-				model: nursingHome.language,
 				required: true,
 			},
 			{
 				label: labelLanguageInfo,
 				type: InputTypes.textarea,
 				name: "language_info",
-				model: nursingHome.language_info,
 			},
 			{
 				label: labelLAHapartments,
 				type: InputTypes.checkbox,
 				name: "lah",
-				model: nursingHome.lah,
 			},
 		];
 
@@ -372,46 +360,39 @@ const PageUpdate: FC = () => {
 				label: labelAddress,
 				type: InputTypes.text,
 				name: "address",
-				model: nursingHome.address,
 				required: true,
 			},
 			{
 				label: labelPostalCode,
 				type: InputTypes.text,
 				name: "postal_code",
-				model: nursingHome.postal_code,
 				required: true,
 			},
 			{
 				label: labelCity,
 				type: InputTypes.text,
 				name: "city",
-				model: nursingHome.city,
 				required: true,
 			},
 			{
 				label: labelDistrict,
 				type: InputTypes.text,
 				name: "district",
-				model: nursingHome.district,
 			},
 			{
 				label: labelWebpage,
 				type: InputTypes.url,
 				name: "www",
-				model: nursingHome.www,
 			},
 			{
 				label: labelArrivalGuidePublicTransit,
 				type: InputTypes.textarea,
 				name: "arrival_guide_public_transit",
-				model: nursingHome.arrival_guide_public_transit,
 			},
 			{
 				label: labelArrivalGuideCar,
 				type: InputTypes.textarea,
 				name: "arrival_guide_car",
-				model: nursingHome.arrival_guide_car,
 			},
 		];
 
@@ -420,20 +401,17 @@ const PageUpdate: FC = () => {
 				label: labelCookingMethod,
 				type: InputTypes.text,
 				name: "meals_preparation",
-				model: nursingHome.meals_preparation,
 				required: true,
 			},
 			{
 				label: labelFoodMoreInfo,
 				type: InputTypes.textarea,
 				name: "meals_info",
-				model: nursingHome.meals_info,
 			},
 			{
 				label: labelLinkMenu,
 				type: InputTypes.url,
 				name: "menu_link",
-				model: nursingHome.menu_link,
 			},
 		];
 
@@ -442,25 +420,21 @@ const PageUpdate: FC = () => {
 				label: labelActivies,
 				type: InputTypes.textarea,
 				name: "activities_info",
-				model: nursingHome.activities_info,
 			},
 			{
 				label: labelLinkMoreInfoActivies,
 				type: InputTypes.url,
 				name: "activities_link",
-				model: nursingHome.activities_link,
 			},
 			{
 				label: labelOutdoorActivies,
 				type: InputTypes.textarea,
 				name: "outdoors_possibilities_info",
-				model: nursingHome.outdoors_possibilities_info,
 			},
 			{
 				label: labelLinkMoreInfoOutdoor,
 				type: InputTypes.url,
 				name: "outdoors_possibilities_link",
-				model: nursingHome.outdoors_possibilities_link,
 			},
 		];
 
@@ -469,41 +443,35 @@ const PageUpdate: FC = () => {
 				label: labelVisitingInfo,
 				type: InputTypes.textarea,
 				name: "tour_info",
-				model: nursingHome.tour_info,
 			},
 			{
 				label: labelContactName,
 				type: InputTypes.text,
 				name: "contact_name",
-				model: nursingHome.contact_name,
 				required: true,
 			},
 			{
 				label: labelContactTitle,
 				type: InputTypes.text,
 				name: "contact_title",
-				model: nursingHome.contact_title,
 				required: true,
 			},
 			{
 				label: labelContactPhone,
 				type: InputTypes.tel,
 				name: "contact_phone",
-				model: nursingHome.contact_phone,
 				required: true,
 			},
 			{
 				label: labelContactEmail,
 				type: InputTypes.email,
 				name: "email",
-				model: nursingHome.email,
 				required: true,
 			},
 			{
 				label: labelContactPhoneInfo,
 				type: InputTypes.textarea,
 				name: "contact_phone_info",
-				model: nursingHome.contact_phone_info,
 			},
 		];
 
@@ -512,7 +480,6 @@ const PageUpdate: FC = () => {
 				label: labelAccessibility,
 				type: InputTypes.textarea,
 				name: "accessibility_info",
-				model: nursingHome.accessibility_info,
 			},
 		];
 
@@ -521,13 +488,11 @@ const PageUpdate: FC = () => {
 				label: labelPersonnel,
 				type: InputTypes.textarea,
 				name: "staff_info",
-				model: nursingHome.staff_info,
 			},
 			{
 				label: labelLinkMoreInfoPersonnel,
 				type: InputTypes.url,
 				name: "staff_satisfaction_info",
-				model: nursingHome.staff_satisfaction_info,
 			},
 		];
 
@@ -536,7 +501,6 @@ const PageUpdate: FC = () => {
 				label: labelOtherServices,
 				type: InputTypes.textarea,
 				name: "other_services",
-				model: nursingHome.other_services,
 			},
 		];
 
@@ -545,7 +509,6 @@ const PageUpdate: FC = () => {
 				label: labelNearbyServices,
 				type: InputTypes.textarea,
 				name: "nearby_services",
-				model: nursingHome.nearby_services,
 			},
 		];
 	}
@@ -679,115 +642,130 @@ const PageUpdate: FC = () => {
 		}
 	};
 
-	const getInputElement = (field: InputField, index: number): JSX.Element => {
-		if (field.type === "textarea") {
-			return (
-				<div className="field" key={`${field.name}-${index}`}>
-					<label htmlFor={field.name}>{field.label}</label>
-					<div className="control">
-						<textarea
-							className={
-								field.required && formErrors[field.name]
-									? "error"
-									: ""
-							}
-							rows={5}
-							value={(field.model as string) || ""}
-							name={field.name}
-							id={field.name}
-							onChange={event =>
-								handleInputChange(field, event.target.value)
-							}
-							required={field.required}
-							onBlur={event =>
-								handleInputBlur(field, event.target.value)
-							}
-						></textarea>
+	const getInputElement = (
+		field: InputField,
+		index: number,
+	): JSX.Element | null => {
+		if (nursingHome) {
+			if (field.type === "textarea") {
+				return (
+					<div className="field" key={`${field.name}-${index}`}>
+						<label htmlFor={field.name}>{field.label}</label>
+						<div className="control">
+							<textarea
+								className={
+									field.required && formErrors[field.name]
+										? "error"
+										: ""
+								}
+								rows={5}
+								value={
+									(nursingHome[field.name] as string) || ""
+								}
+								name={field.name}
+								id={field.name}
+								onChange={event =>
+									handleInputChange(field, event.target.value)
+								}
+								required={field.required}
+								onBlur={event =>
+									handleInputBlur(field, event.target.value)
+								}
+							></textarea>
+							{field.required && formErrors[field.name] ? (
+								<span className="icon"></span>
+							) : null}
+						</div>
 						{field.required && formErrors[field.name] ? (
-							<span className="icon"></span>
+							<p className="help">{textFieldIsRequired}</p>
 						) : null}
 					</div>
-					{field.required && formErrors[field.name] ? (
-						<p className="help">{textFieldIsRequired}</p>
-					) : null}
-				</div>
-			);
-		} else if (field.type === "checkbox") {
-			return (
-				<div className="field" key={`${field.name}-${index}`}>
-					<Checkbox
-						name={field.name}
-						id={field.name}
-						onChange={checked => handleInputChange(field, checked)}
-						isChecked={(field.model as boolean) || false}
-					>
-						{field.label}
-					</Checkbox>
-				</div>
-			);
-		} else if (field.type === "radio") {
-			return (
-				<fieldset className="field" key={`${field.name}-${index}`}>
-					<legend>{labelAra}</legend>
-					{field.buttons
-						? field.buttons.map(button => {
-								return (
-									<Radio
-										key={`${field.name}-${button.value}`}
-										id={`${field.name}-${button.value}`}
-										name={field.name}
-										isSelected={
-											field.model === button.value
-										}
-										value={button.value}
-										onChange={isChecked => {
-											if (isChecked) {
-												handleInputChange(
-													field,
-													button.value,
-												);
+				);
+			} else if (field.type === "checkbox") {
+				return (
+					<div className="field" key={`${field.name}-${index}`}>
+						<Checkbox
+							name={field.name}
+							id={field.name}
+							onChange={checked =>
+								handleInputChange(field, checked)
+							}
+							isChecked={
+								(nursingHome[field.name] as boolean) || false
+							}
+						>
+							{field.label}
+						</Checkbox>
+					</div>
+				);
+			} else if (field.type === "radio") {
+				return (
+					<fieldset className="field" key={`${field.name}-${index}`}>
+						<legend>{labelAra}</legend>
+						{field.buttons
+							? field.buttons.map(button => {
+									return (
+										<Radio
+											key={`${field.name}-${button.value}`}
+											id={`${field.name}-${button.value}`}
+											name={field.name}
+											isSelected={
+												(nursingHome[
+													field.name
+												] as string) === button.value
 											}
-										}}
-									>
-										{button.label}
-									</Radio>
-								);
-						  })
-						: null}
-				</fieldset>
-			);
-		} else {
-			return (
-				<div className="field" key={`${field.name}-${index}`}>
-					<label htmlFor={field.name}>{field.label}</label>
-					<div className="control">
-						<input
-							className={
-								field.required && formErrors[field.name]
-									? "error"
-									: ""
-							}
-							value={(field.model as string | number) || ""}
-							name={field.name}
-							id={field.name}
-							type={field.type}
-							onChange={event =>
-								handleInputChange(field, event.target.value)
-							}
-							onBlur={event =>
-								handleInputBlur(field, event.target.value)
-							}
-						/>
+											value={button.value}
+											onChange={isChecked => {
+												if (isChecked) {
+													handleInputChange(
+														field,
+														button.value,
+													);
+												}
+											}}
+										>
+											{button.label}
+										</Radio>
+									);
+							  })
+							: null}
+					</fieldset>
+				);
+			} else {
+				return (
+					<div className="field" key={`${field.name}-${index}`}>
+						<label htmlFor={field.name}>{field.label}</label>
+						<div className="control">
+							<input
+								className={
+									field.required && formErrors[field.name]
+										? "error"
+										: ""
+								}
+								value={nursingHome[field.name] as string}
+								name={field.name}
+								id={field.name}
+								type={field.type}
+								onChange={event =>
+									handleInputChange(field, event.target.value)
+								}
+								onBlur={event =>
+									handleInputBlur(field, event.target.value)
+								}
+							/>
+							{field.required && formErrors[field.name] ? (
+								<span className="icon"></span>
+							) : null}
+						</div>
 						{field.required && formErrors[field.name] ? (
-							<span className="icon"></span>
+							<p className="help">{textFieldIsRequired}</p>
 						) : null}
 					</div>
-					{field.required && formErrors[field.name] ? (
-						<p className="help">{textFieldIsRequired}</p>
-					) : null}
-				</div>
-			);
+				);
+			}
 		}
+
+		return null;
 	};
 
 	return (

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -39,6 +39,19 @@ interface InputField {
 	buttons?: { value: string; label: string }[];
 }
 
+type OptionalProps<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+type TransformableNursingHome = OptionalProps<
+	NursingHome,
+	| "id"
+	| "pic_digests"
+	| "pics"
+	| "pic_captions"
+	| "report_status"
+	| "rating"
+	| "geolocation"
+	| "has_vacancy"
+>;
+
 type NursingHomeUpdateData = Omit<
 	NursingHome,
 	| "id"
@@ -67,7 +80,7 @@ const requestVacancyStatusUpdate = async (
 	id: string,
 	key: string,
 	status: boolean,
-	images: any,
+	images: object[],
 ): Promise<void> => {
 	await axios.post(
 		`${config.API_URL}/nursing-homes/${id}/vacancy-status/${key}`,
@@ -543,7 +556,7 @@ const PageUpdate: FC = () => {
 			await requestVacancyStatusUpdate(id, key, formState, imageState);
 
 			if (nursingHome) {
-				const transformNursingHomeData: any = {
+				const transformNursingHomeData: TransformableNursingHome = {
 					...nursingHome,
 				};
 
@@ -555,7 +568,6 @@ const PageUpdate: FC = () => {
 				delete transformNursingHomeData.rating;
 				delete transformNursingHomeData.geolocation;
 				delete transformNursingHomeData.has_vacancy;
-				delete transformNursingHomeData.basic_update_key;
 
 				const nursingHomeUpdateData: NursingHomeUpdateData = transformNursingHomeData;
 

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -657,13 +657,15 @@ const PageUpdate: FC = () => {
 				case "textarea":
 					return (
 						<div className="field" key={`${field.name}-${index}`}>
-							<label htmlFor={field.name}>{field.label}</label>
+							<label className="label" htmlFor={field.name}>
+								{field.label}
+							</label>
 							<div className="control">
 								<textarea
 									className={
 										field.required && !field.valid
-											? "error"
-											: ""
+											? "input error"
+											: "input"
 									}
 									rows={5}
 									value={
@@ -754,13 +756,15 @@ const PageUpdate: FC = () => {
 				default:
 					return (
 						<div className="field" key={`${field.name}-${index}`}>
-							<label htmlFor={field.name}>{field.label}</label>
+							<label className="label" htmlFor={field.name}>
+								{field.label}
+							</label>
 							<div className="control">
 								<input
 									className={
 										field.required && !field.valid
-											? "error"
-											: ""
+											? "input error"
+											: "input"
 									}
 									value={nursingHome[field.name] as string}
 									name={field.name}

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -8,6 +8,7 @@ import axios from "axios";
 import config from "./config";
 import { GetNursingHomeResponse } from "./PageNursingHome";
 import { NursingHome, NursingHomeImageName } from "./types";
+import Checkbox from "./Checkbox";
 
 interface VacancyStatus {
 	has_vacancy: boolean;
@@ -133,57 +134,6 @@ const PageUpdate: FC = () => {
 		"nursinghome_layout",
 	];
 
-	const removeImage = (id: string) => {
-		const index = imageState.findIndex(x => x.name === id);
-		imageState[index].remove = true;
-		imageState[index].value = "";
-	};
-
-	const updateImageState = (id: string, state: string) => {
-		const index = imageState.findIndex(x => x.name === id);
-		imageState[index].value = state;
-		imageState[index].remove = false;
-	};
-
-	const updateCaptionState = (id: string, state: string) => {
-		const index = imageState.findIndex(x => x.name === id);
-		imageState[index].text = state;
-	};
-
-	const title = useT("pageUpdateTitle");
-	const freeApartmentsStatus = useT("freeApartmentsStatus");
-	const organizationLogo = useT("organizationLogo");
-	const organizationPhotos = useT("organizationPhotos");
-	const organizationPhotosGuide = useT("organizationPhotosGuide");
-	const intro = useT("pageUpdateIntro");
-	const labelTrue = useT("vacancyTrue");
-	const labelFalse = useT("vacancyFalse");
-	const loadingText = useT("loadingText");
-	const nursingHomeName = useT("nursingHome");
-	const status = useT("status");
-	const lastUpdate = useT("lastUpdate");
-	const noUpdate = useT("noUpdate");
-	const btnSave = useT("btnSave");
-	const cancel = useT("cancel");
-
-	const updatePopupSaved = useT("saved");
-	const updatePopupSaving = useT("saving");
-
-	const handleSubmit = async (
-		e: React.FormEvent<HTMLFormElement>,
-	): Promise<void> => {
-		e.preventDefault();
-		setPopupState("saving");
-		await requestVacancyStatusUpdate(id, key, formState, imageState);
-		setPopupState("saved");
-		setVacancyStatus(null);
-	};
-
-	const cancelEdit = (e: React.FormEvent<HTMLButtonElement>): void => {
-		e.preventDefault();
-		window.location.href = window.location.pathname + "/peruuta";
-	};
-
 	let basicFields: InputField[] = [];
 	let contactFields: InputField[] = [];
 	let foodFields: InputField[] = [];
@@ -221,10 +171,22 @@ const PageUpdate: FC = () => {
 				value: nursingHome.construction_year,
 			},
 			{
+				label: "Tietoja rakennuksesta",
+				type: "textarea",
+				name: "building_info",
+				value: nursingHome.building_info,
+			},
+			{
 				label: "Asuntojen määrä",
 				type: "number",
 				name: "apartment_count",
 				value: nursingHome.apartment_count,
+			},
+			{
+				label: "Asuntojen määrä, lisätietoja",
+				type: "textarea",
+				name: "apartment_count_info",
+				value: nursingHome.apartment_count_info,
 			},
 			{
 				label: "Asuntojen neliömäärä",
@@ -233,16 +195,34 @@ const PageUpdate: FC = () => {
 				value: nursingHome.apartment_square_meters,
 			},
 			{
+				label: "Asunnoissa oma kylpyhuone",
+				type: "checkbox",
+				name: "apartments_have_bathroom",
+				value: nursingHome.apartments_have_bathroom,
+			},
+			{
 				label: "Vuokran määrä",
 				type: "text",
 				name: "rent",
 				value: nursingHome.rent,
 			},
 			{
+				label: "Vuokra lisätietoja",
+				type: "textarea",
+				name: "rent_info",
+				value: nursingHome.rent_info,
+			},
+			{
 				label: "Palvelukieli",
 				type: "text",
 				name: "language",
 				value: nursingHome.language,
+			},
+			{
+				label: "Palvelukieli lisätietoja",
+				type: "textarea",
+				name: "language_info",
+				value: nursingHome.language_info,
 			},
 			{
 				label: "Lyhytaikaisen asumisen asuntoja",
@@ -270,6 +250,12 @@ const PageUpdate: FC = () => {
 				type: "text",
 				name: "city",
 				value: nursingHome.city,
+			},
+			{
+				label: "Kaupunginosa",
+				type: "text",
+				name: "district",
+				value: nursingHome.district,
 			},
 			{
 				label: "Verkkosivut",
@@ -330,6 +316,18 @@ const PageUpdate: FC = () => {
 				type: "text",
 				name: "activities_link",
 				value: nursingHome.activities_link,
+			},
+			{
+				label: "Ulkoilumahdollisuudet",
+				type: "textarea",
+				name: "outdoors_possibilities_info",
+				value: nursingHome.outdoors_possibilities_info,
+			},
+			{
+				label: "Ulkoilumahdollisuudet (linkki)",
+				type: "text",
+				name: "outdoors_possibilities_link",
+				value: nursingHome.outdoors_possibilities_link,
 			},
 		];
 
@@ -421,41 +419,101 @@ const PageUpdate: FC = () => {
 		];
 	}
 
-	const getInputField = (field: InputField): JSX.Element => {
+	const removeImage = (id: string) => {
+		const index = imageState.findIndex(x => x.name === id);
+		imageState[index].remove = true;
+		imageState[index].value = "";
+	};
+
+	const updateImageState = (id: string, state: string) => {
+		const index = imageState.findIndex(x => x.name === id);
+		imageState[index].value = state;
+		imageState[index].remove = false;
+	};
+
+	const updateCaptionState = (id: string, state: string) => {
+		const index = imageState.findIndex(x => x.name === id);
+		imageState[index].text = state;
+	};
+
+	const title = useT("pageUpdateTitle");
+	const freeApartmentsStatus = useT("freeApartmentsStatus");
+	const organizationLogo = useT("organizationLogo");
+	const organizationPhotos = useT("organizationPhotos");
+	const organizationPhotosGuide = useT("organizationPhotosGuide");
+	const intro = useT("pageUpdateIntro");
+	const labelTrue = useT("vacancyTrue");
+	const labelFalse = useT("vacancyFalse");
+	const loadingText = useT("loadingText");
+	const nursingHomeName = useT("nursingHome");
+	const status = useT("status");
+	const lastUpdate = useT("lastUpdate");
+	const noUpdate = useT("noUpdate");
+	const btnSave = useT("btnSave");
+	const cancel = useT("cancel");
+
+	const updatePopupSaved = useT("saved");
+	const updatePopupSaving = useT("saving");
+
+	const handleSubmit = async (
+		e: React.FormEvent<HTMLFormElement>,
+	): Promise<void> => {
+		e.preventDefault();
+		setPopupState("saving");
+		await requestVacancyStatusUpdate(id, key, formState, imageState);
+		setPopupState("saved");
+		setVacancyStatus(null);
+	};
+
+	const cancelEdit = (e: React.FormEvent<HTMLButtonElement>): void => {
+		e.preventDefault();
+		window.location.href = window.location.pathname + "/peruuta";
+	};
+
+	const getInputElement = (field: InputField, index: number): JSX.Element => {
 		if (field.type === "textarea") {
 			return (
-				<div className="page-update-input">
+				<div
+					className="page-update-input"
+					key={`${field.name}_${index}`}
+				>
 					<label htmlFor={field.name}>{field.label}</label>
 					<textarea
-						value={field.value as string}
+						value={(field.value as string) || ""}
 						name={field.name}
 						id={field.name}
+						onChange={() => {}}
 					></textarea>
 				</div>
 			);
 		} else if (field.type === "checkbox") {
 			return (
-				<div className="page-update-input">
-					<label htmlFor={field.name}>
-						{field.label}{" "}
-						<input
-							type={field.type}
-							name={field.name}
-							id={field.name}
-							checked={field.value as boolean}
-						/>
-					</label>
+				<div
+					className="page-update-input"
+					key={`${field.name}_${index}`}
+				>
+					<Checkbox
+						name={field.name}
+						id={field.name}
+						onChange={() => {}}
+						children={field.label}
+						isChecked={field.value as boolean}
+					/>
 				</div>
 			);
 		} else {
 			return (
-				<div className="page-update-input">
+				<div
+					className="page-update-input"
+					key={`${field.name}_${index}`}
+				>
 					<label htmlFor={field.name}>{field.label}</label>
 					<input
-						value={field.value as string}
+						value={(field.value as string) || ""}
 						name={field.name}
 						id={field.name}
 						type={field.type}
+						onChange={() => {}}
 					/>
 				</div>
 			);
@@ -564,71 +622,88 @@ const PageUpdate: FC = () => {
 							</h3>
 							<p>{organizationPhotosGuide}</p>
 							<div className="flex-container">
-								{nursinghomeImageTypes.map(imageType => (
-									<ImageUpload
-										nursingHome={nursingHome}
-										imageName={
-											imageType as NursingHomeImageName
-										}
-										useButton={false}
-										textAreaClass="nursinghome-upload-caption"
-										onRemove={() => {
-											removeImage(imageType);
-										}}
-										onChange={file => {
-											updateImageState(imageType, file);
-										}}
-										onCaptionChange={text => {
-											updateCaptionState(imageType, text);
-										}}
-									/>
-								))}
+								{nursinghomeImageTypes.map(
+									(imageType, index) => (
+										<ImageUpload
+											key={`${imageType}_${index}`}
+											nursingHome={nursingHome}
+											imageName={
+												imageType as NursingHomeImageName
+											}
+											useButton={false}
+											textAreaClass="nursinghome-upload-caption"
+											onRemove={() => {
+												removeImage(imageType);
+											}}
+											onChange={file => {
+												updateImageState(
+													imageType,
+													file,
+												);
+											}}
+											onCaptionChange={text => {
+												updateCaptionState(
+													imageType,
+													text,
+												);
+											}}
+										/>
+									),
+								)}
 							</div>
 						</div>
 						<div className="page-update-section">
 							<h3>Perustiedot</h3>
-							{basicFields.map(field => getInputField(field))}
+							{basicFields.map((field, index) =>
+								getInputElement(field, index),
+							)}
 						</div>
 						<div className="page-update-section">
 							<h3>Yhteystiedot</h3>
-							{contactFields.map(field => getInputField(field))}
+							{contactFields.map((field, index) =>
+								getInputElement(field, index),
+							)}
 						</div>
 						<div className="page-update-section">
 							<h3>Ruoka</h3>
-							{foodFields.map(field => getInputField(field))}
+							{foodFields.map((field, index) =>
+								getInputElement(field, index),
+							)}
 						</div>
 						<div className="page-update-section">
 							<h3>Toiminta</h3>
-							{activitiesFields.map(field =>
-								getInputField(field),
+							{activitiesFields.map((field, index) =>
+								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>Hoivakotiin tutustuminen</h3>
-							{nursingHomeContactFields.map(field =>
-								getInputField(field),
+							{nursingHomeContactFields.map((field, index) =>
+								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>Esteettömyys</h3>
-							{accessibilityFields.map(field =>
-								getInputField(field),
+							{accessibilityFields.map((field, index) =>
+								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>Henkilökunta</h3>
-							{staffFields.map(field => getInputField(field))}
+							{staffFields.map((field, index) =>
+								getInputElement(field, index),
+							)}
 						</div>
 						<div className="page-update-section">
 							<h3>Muut hoivakodin palvelut</h3>
-							{otherServicesFields.map(field =>
-								getInputField(field),
+							{otherServicesFields.map((field, index) =>
+								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
 							<h3>Lähellä olevat palvelut</h3>
-							{nearbyServicesFields.map(field =>
-								getInputField(field),
+							{nearbyServicesFields.map((field, index) =>
+								getInputElement(field, index),
 							)}
 						</div>
 					</>

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -2,12 +2,11 @@ import React, { FC, useEffect, useState } from "react";
 import { useT } from "../i18n";
 import "../styles/PageUpdate.scss";
 import Radio from "./Radio";
-// import ImageUpload from "./ImageUpload";
 import { Link, useParams } from "react-router-dom";
 import axios from "axios";
 import config from "./config";
 import { GetNursingHomeResponse } from "./PageNursingHome";
-import { NursingHome, NursingHomeImageName } from "./types";
+import { NursingHome } from "./types";
 import Checkbox from "./Checkbox";
 
 enum InputTypes {
@@ -22,6 +21,7 @@ enum InputTypes {
 }
 
 type NursingHomeKey = keyof NursingHome;
+type InputFieldValue = string | number | boolean;
 
 type NursingHomeUpdateData = Omit<
 	NursingHome,
@@ -53,7 +53,8 @@ interface InputField {
 	buttons?: { value: string | boolean; label: string }[];
 	required?: boolean;
 	valid?: boolean;
-	change?: (arg: any) => void;
+	touched?: boolean;
+	change?: (arg: InputFieldValue) => void;
 }
 
 const formatDate = (dateString: string | null): string => {
@@ -71,7 +72,6 @@ const requestVacancyStatusUpdate = async (
 	id: string,
 	key: string,
 	status: boolean,
-	images: object[],
 ): Promise<void> => {
 	await axios.post(
 		`${config.API_URL}/nursing-homes/${id}/vacancy-status/${key}`,
@@ -80,15 +80,6 @@ const requestVacancyStatusUpdate = async (
 			has_vacancy: status,
 		},
 	);
-
-	for (const image of images) {
-		await axios.post(
-			`${config.API_URL}/nursing-homes/${id}/update-image/${key}`,
-			{
-				image: image,
-			},
-		);
-	}
 };
 
 const requestNursingHomeUpdate = async (
@@ -168,9 +159,7 @@ const PageUpdate: FC = () => {
 	const labelContactDescription = useT("contactDescription");
 	const title = useT("pageUpdateTitle");
 	const freeApartmentsStatus = useT("freeApartmentsStatus");
-	// const organizationLogo = useT("organizationLogo");
-	// const organizationPhotos = useT("organizationPhotos");
-	// const organizationPhotosGuide = useT("organizationPhotosGuide");
+
 	const intro = useT("pageUpdateIntro");
 	const labelTrue = useT("vacancyTrue");
 	const labelFalse = useT("vacancyFalse");
@@ -193,14 +182,16 @@ const PageUpdate: FC = () => {
 				type: InputTypes.textarea,
 				name: "summary",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelOwner,
 				type: InputTypes.text,
 				name: "owner",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelAra,
@@ -216,7 +207,8 @@ const PageUpdate: FC = () => {
 				type: InputTypes.number,
 				name: "construction_year",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelBuildingInfo,
@@ -228,7 +220,8 @@ const PageUpdate: FC = () => {
 				type: InputTypes.number,
 				name: "apartment_count",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelApartmentCountInfo,
@@ -240,7 +233,8 @@ const PageUpdate: FC = () => {
 				type: InputTypes.text,
 				name: "apartment_square_meters",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelApartmentsHaveBathroom,
@@ -252,7 +246,8 @@ const PageUpdate: FC = () => {
 				type: InputTypes.text,
 				name: "rent",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelRentInfo,
@@ -264,7 +259,8 @@ const PageUpdate: FC = () => {
 				type: InputTypes.text,
 				name: "language",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelLanguageInfo,
@@ -278,35 +274,40 @@ const PageUpdate: FC = () => {
 				type: InputTypes.text,
 				name: "address",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelPostalCode,
 				type: InputTypes.text,
 				name: "postal_code",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelCity,
 				type: InputTypes.text,
 				name: "city",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelDistrict,
 				type: InputTypes.text,
 				name: "district",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelWebpage,
 				type: InputTypes.url,
 				name: "www",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelArrivalGuidePublicTransit,
@@ -325,21 +326,24 @@ const PageUpdate: FC = () => {
 				type: InputTypes.text,
 				name: "meals_preparation",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelFoodMoreInfo,
 				type: InputTypes.textarea,
 				name: "meals_info",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelLinkMenu,
 				type: InputTypes.url,
 				name: "menu_link",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 		],
 		activitiesFields: [
@@ -348,28 +352,32 @@ const PageUpdate: FC = () => {
 				type: InputTypes.textarea,
 				name: "activities_info",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelLinkMoreInfoActivies,
 				type: InputTypes.url,
 				name: "activities_link",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelOutdoorActivies,
 				type: InputTypes.textarea,
 				name: "outdoors_possibilities_info",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelLinkMoreInfoOutdoor,
 				type: InputTypes.url,
 				name: "outdoors_possibilities_link",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 		],
 		nursingHomeContactFields: [
@@ -378,35 +386,40 @@ const PageUpdate: FC = () => {
 				type: InputTypes.textarea,
 				name: "tour_info",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelContactName,
 				type: InputTypes.text,
 				name: "contact_name",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelContactTitle,
 				type: InputTypes.text,
 				name: "contact_title",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelContactPhone,
 				type: InputTypes.tel,
 				name: "contact_phone",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelContactEmail,
 				type: InputTypes.email,
 				name: "email",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 			{
 				label: labelContactPhoneInfo,
@@ -420,7 +433,8 @@ const PageUpdate: FC = () => {
 				type: InputTypes.textarea,
 				name: "accessibility_info",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 		],
 		staffFields: [
@@ -448,7 +462,8 @@ const PageUpdate: FC = () => {
 				type: InputTypes.textarea,
 				name: "nearby_services",
 				required: true,
-				valid: true,
+				valid: false,
+				touched: false,
 			},
 		],
 		vacancyFields: [
@@ -460,10 +475,8 @@ const PageUpdate: FC = () => {
 					{ value: false, label: labelFalse },
 				],
 				name: "has_vacancy",
-				change: (selected: boolean) => {
-					console.log(selected);
-
-					setHasVacancy(selected);
+				change: (selected: InputFieldValue) => {
+					setHasVacancy(selected as boolean);
 				},
 			},
 			{
@@ -473,6 +486,8 @@ const PageUpdate: FC = () => {
 			},
 		],
 	});
+
+	const [formIsValid, setFormIsValid] = useState(false);
 
 	if (!id || !key) throw new Error("Invalid URL!");
 
@@ -507,63 +522,20 @@ const PageUpdate: FC = () => {
 		}
 	}, [id, key, popupState, vacancyStatus]);
 
-	const imageState = [
-		{ name: "overview_outside", remove: false, value: "", text: "" },
-		{ name: "apartment", remove: false, value: "", text: "" },
-		{ name: "lounge", remove: false, value: "", text: "" },
-		{ name: "dining_room", remove: false, value: "", text: "" },
-		{ name: "outside", remove: false, value: "", text: "" },
-		{ name: "entrance", remove: false, value: "", text: "" },
-		{ name: "bathroom", remove: false, value: "", text: "" },
-		{ name: "apartment_layout", remove: false, value: "", text: "" },
-		{ name: "nursinghome_layout", remove: false, value: "", text: "" },
-		{ name: "owner_logo", remove: false, value: "", text: "" },
-	];
+	const validateField = (value: any): boolean => {
+		return value !== null && value !== "";
+	};
 
-	// const nursinghomeImageTypes = [
-	// 	"overview_outside",
-	// 	"apartment",
-	// 	"lounge",
-	// 	"dining_room",
-	// 	"outside",
-	// 	"entrance",
-	// 	"bathroom",
-	// 	"apartment_layout",
-	// 	"nursinghome_layout",
-	// ];
+	const getAllFields = (): InputField[] => {
+		let fields: InputField[] = [];
 
-	// const removeImage = (id: string): void => {
-	// 	const index = imageState.findIndex(x => x.name === id);
-	// 	imageState[index].remove = true;
-	// 	imageState[index].value = "";
-	// };
+		const sections = Object.keys(form).map(section => form[section]);
 
-	// const updateImageState = (id: string, state: string): void => {
-	// 	const index = imageState.findIndex(x => x.name === id);
-	// 	imageState[index].value = state;
-	// 	imageState[index].remove = false;
-	// };
+		for (const section of sections) {
+			fields = [...fields, ...section];
+		}
 
-	// const updateCaptionState = (id: string, state: string): void => {
-	// 	const index = imageState.findIndex(x => x.name === id);
-	// 	imageState[index].text = state;
-	// };
-
-	const validForm = (): boolean => {
-		let formIsValid = true;
-
-		Object.keys(form).forEach(section => {
-			const invalidFields =
-				form[section].filter((field: InputField) => {
-					return field.valid === false;
-				}).length > 0;
-
-			if (invalidFields) {
-				formIsValid = false;
-			}
-		});
-
-		return formIsValid;
+		return fields;
 	};
 
 	const handleSubmit = async (
@@ -572,32 +544,21 @@ const PageUpdate: FC = () => {
 		try {
 			event.preventDefault();
 
-			if (validForm()) {
+			if (formIsValid) {
 				setPopupState("saving");
 
-				await requestVacancyStatusUpdate(
-					id,
-					key,
-					hasVacancy,
-					imageState,
-				);
+				await requestVacancyStatusUpdate(id, key, hasVacancy);
 
 				if (nursingHome) {
-					let fields: InputField[] = [];
-
-					Object.keys(form)
-						.map(section => form[section])
-						.forEach(section => {
-							fields = [...fields, ...section];
-						});
+					const fields = getAllFields();
 
 					const formData: any = {};
 
-					fields.forEach(field => {
+					for (const field of fields) {
 						if (field.name !== "has_vacancy") {
 							formData[field.name] = nursingHome[field.name];
 						}
-					});
+					}
 
 					const updateNursingHomeData: NursingHomeUpdateData = formData;
 
@@ -624,34 +585,81 @@ const PageUpdate: FC = () => {
 		window.location.href = window.location.pathname + "/peruuta";
 	};
 
-	const validateField = (value: string | number): boolean => {
-		return value !== null && value !== "";
+	const validateForm = (): void => {
+		if (nursingHome) {
+			let validForm = true;
+
+			const validatedForm = { ...form };
+
+			for (const section in validatedForm) {
+				const fields = validatedForm[section];
+				const validatedFields = [];
+
+				for (const field of fields) {
+					if (field.required) {
+						const validField = validateField(
+							nursingHome[field.name],
+						);
+
+						if (!validField) {
+							validForm = false;
+						}
+
+						validatedFields.push({
+							...field,
+							touched: true,
+							valid: validField,
+						});
+					} else {
+						validatedFields.push(field);
+					}
+				}
+
+				validatedForm[section] = validatedFields;
+			}
+
+			setForm(validatedForm);
+			setFormIsValid(validForm);
+		}
 	};
 
 	const handleInputBlur = (
 		field: InputField,
 		section: string,
-		value: string | number,
+		value: InputFieldValue,
 	): void => {
 		const { name, required } = field;
 
 		if (required) {
 			const validField = validateField(value);
+
 			const fields = [...form[section]];
 			const index = fields.findIndex(input => input.name === name);
 
-			fields[index] = { ...field, valid: validField };
+			fields[index] = { ...field, touched: true, valid: validField };
 
 			setForm({ ...form, [section]: fields });
 		}
+
+		validateForm();
 	};
 
 	const handleInputChange = (
 		field: InputField,
-		value: string | number | boolean,
+		section: string,
+		value: InputFieldValue,
 	): void => {
 		if (nursingHome) {
-			const { name, type } = field;
+			const { name, type, touched } = field;
+
+			if (!touched) {
+				const fields = [...form[section]];
+				const index = fields.findIndex(input => input.name === name);
+
+				fields[index] = { ...field, touched: true };
+
+				setForm({ ...form, [section]: fields });
+			}
 
 			setNursingHome({
 				...nursingHome,
@@ -661,6 +669,8 @@ const PageUpdate: FC = () => {
 						: value,
 			});
 		}
+
+		validateForm();
 	};
 
 	const getInputElement = (
@@ -669,6 +679,9 @@ const PageUpdate: FC = () => {
 		index: number,
 	): JSX.Element | null => {
 		if (nursingHome) {
+			const fieldInvalid =
+				field.required && field.touched && !field.valid;
+
 			switch (field.type) {
 				case "textarea":
 					return (
@@ -679,9 +692,7 @@ const PageUpdate: FC = () => {
 							<div className="control">
 								<textarea
 									className={
-										field.required && !field.valid
-											? "input error"
-											: "input"
+										fieldInvalid ? "input error" : "input"
 									}
 									rows={5}
 									value={
@@ -693,6 +704,7 @@ const PageUpdate: FC = () => {
 									onChange={event =>
 										handleInputChange(
 											field,
+											section,
 											event.target.value,
 										)
 									}
@@ -705,11 +717,11 @@ const PageUpdate: FC = () => {
 										)
 									}
 								></textarea>
-								{field.required && !field.valid ? (
+								{fieldInvalid ? (
 									<span className="icon"></span>
 								) : null}
 							</div>
-							{field.required && !field.valid ? (
+							{fieldInvalid ? (
 								<p className="help">{textFieldIsRequired}</p>
 							) : null}
 						</div>
@@ -721,7 +733,7 @@ const PageUpdate: FC = () => {
 								name={field.name}
 								id={field.name}
 								onChange={checked =>
-									handleInputChange(field, checked)
+									handleInputChange(field, section, checked)
 								}
 								isChecked={
 									(nursingHome[field.name] as boolean) ||
@@ -762,6 +774,7 @@ const PageUpdate: FC = () => {
 
 													handleInputChange(
 														field,
+														section,
 														button.value,
 													);
 												}}
@@ -782,9 +795,7 @@ const PageUpdate: FC = () => {
 							<div className="control">
 								<input
 									className={
-										field.required && !field.valid
-											? "input error"
-											: "input"
+										fieldInvalid ? "input error" : "input"
 									}
 									value={nursingHome[field.name] as string}
 									name={field.name}
@@ -793,6 +804,7 @@ const PageUpdate: FC = () => {
 									onChange={event =>
 										handleInputChange(
 											field,
+											section,
 											event.target.value,
 										)
 									}
@@ -804,11 +816,11 @@ const PageUpdate: FC = () => {
 										)
 									}
 								/>
-								{field.required && !field.valid ? (
+								{fieldInvalid ? (
 									<span className="icon"></span>
 								) : null}
 							</div>
-							{field.required && !field.valid ? (
+							{fieldInvalid ? (
 								<p className="help">{textFieldIsRequired}</p>
 							) : null}
 						</div>
@@ -838,7 +850,11 @@ const PageUpdate: FC = () => {
 								>
 									{cancel}
 								</button>
-								<button type="submit" className="btn">
+								<button
+									type="submit"
+									className="btn page-update-submit"
+									disabled={!formIsValid}
+								>
 									{btnSave}
 								</button>
 
@@ -893,7 +909,12 @@ const PageUpdate: FC = () => {
 									)}
 								</div>
 								<div className="page-update-data">
-									<Link to={"/"}>Lisää kuvia</Link>
+									<Link
+										className="btn update-images-button"
+										to={`/hoivakodit/${id}/paivita/${key}/kuvat`}
+									>
+										Lisää kuvia
+									</Link>
 								</div>
 							</div>
 							<div className="page-update-section">
@@ -984,59 +1005,6 @@ const PageUpdate: FC = () => {
 								)}
 							</div>
 						</form>
-						{/* <div className="page-update-section nursinghome-logo-upload">
-							<h3 className="page-update-minor-title">
-								{organizationLogo}
-							</h3>
-							<ImageUpload
-								nursingHome={nursingHome}
-								imageName={"owner_logo" as NursingHomeImageName}
-								useButton={true}
-								textAreaClass="textarea-hidden"
-								onRemove={() => {
-									removeImage("owner_logo");
-								}}
-								onChange={file => {
-									updateImageState("owner_logo", file);
-								}}
-							/>
-						</div>
-						<div className="page-update-section">
-							<h3 className="page-update-minor-title">
-								{organizationPhotos}
-							</h3>
-							<p>{organizationPhotosGuide}</p>
-							<div className="flex-container">
-								{nursinghomeImageTypes.map(
-									(imageType, index) => (
-										<ImageUpload
-											key={`${imageType}_${index}`}
-											nursingHome={nursingHome}
-											imageName={
-												imageType as NursingHomeImageName
-											}
-											useButton={false}
-											textAreaClass="nursinghome-upload-caption"
-											onRemove={() => {
-												removeImage(imageType);
-											}}
-											onChange={file => {
-												updateImageState(
-													imageType,
-													file,
-												);
-											}}
-											onCaptionChange={text => {
-												updateCaptionState(
-													imageType,
-													text,
-												);
-											}}
-										/>
-									),
-								)}
-							</div>
-						</div> */}
 					</>
 				)}
 			</div>

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -2,8 +2,8 @@ import React, { FC, useEffect, useState } from "react";
 import { useT } from "../i18n";
 import "../styles/PageUpdate.scss";
 import Radio from "./Radio";
-import ImageUpload from "./ImageUpload";
-import { useParams } from "react-router-dom";
+// import ImageUpload from "./ImageUpload";
+import { Link, useParams } from "react-router-dom";
 import axios from "axios";
 import config from "./config";
 import { GetNursingHomeResponse } from "./PageNursingHome";
@@ -50,9 +50,10 @@ interface InputField {
 	label: string;
 	type: InputTypes;
 	name: NursingHomeKey;
-	buttons?: { value: string; label: string }[];
+	buttons?: { value: string | boolean; label: string }[];
 	required?: boolean;
 	valid?: boolean;
+	change?: (arg: any) => void;
 }
 
 const formatDate = (dateString: string | null): string => {
@@ -147,7 +148,7 @@ const PageUpdate: FC = () => {
 	const labelFoodHeader = useT("foodHeader");
 	const labelYes = useT("filterYes");
 	const labelNo = useT("filterNo");
-	const labelSummary = useT("summary");
+	const labelSummary = useT("nursingHomeSummary");
 	const labelBuildingInfo = useT("buildingInfo");
 	const labelApartmentCountInfo = useT("apartmentCountInfo");
 	const labelApartmentsHaveBathroom = useT("apartmentsHaveBathroom");
@@ -164,11 +165,12 @@ const PageUpdate: FC = () => {
 	const labelContactPhone = useT("contactPhone");
 	const labelContactEmail = useT("contactEmail");
 	const labelContactPhoneInfo = useT("contactPhoneInfo");
+	const labelContactDescription = useT("contactDescription");
 	const title = useT("pageUpdateTitle");
 	const freeApartmentsStatus = useT("freeApartmentsStatus");
-	const organizationLogo = useT("organizationLogo");
-	const organizationPhotos = useT("organizationPhotos");
-	const organizationPhotosGuide = useT("organizationPhotosGuide");
+	// const organizationLogo = useT("organizationLogo");
+	// const organizationPhotos = useT("organizationPhotos");
+	// const organizationPhotosGuide = useT("organizationPhotosGuide");
 	const intro = useT("pageUpdateIntro");
 	const labelTrue = useT("vacancyTrue");
 	const labelFalse = useT("vacancyFalse");
@@ -204,7 +206,6 @@ const PageUpdate: FC = () => {
 				label: labelAra,
 				type: InputTypes.radio,
 				name: "ara",
-
 				buttons: [
 					{ value: labelYes, label: labelYes },
 					{ value: labelNo, label: labelNo },
@@ -270,11 +271,6 @@ const PageUpdate: FC = () => {
 				type: InputTypes.textarea,
 				name: "language_info",
 			},
-			{
-				label: labelLAHapartments,
-				type: InputTypes.checkbox,
-				name: "lah",
-			},
 		],
 		contactFields: [
 			{
@@ -302,11 +298,15 @@ const PageUpdate: FC = () => {
 				label: labelDistrict,
 				type: InputTypes.text,
 				name: "district",
+				required: true,
+				valid: true,
 			},
 			{
 				label: labelWebpage,
 				type: InputTypes.url,
 				name: "www",
+				required: true,
+				valid: true,
 			},
 			{
 				label: labelArrivalGuidePublicTransit,
@@ -331,11 +331,15 @@ const PageUpdate: FC = () => {
 				label: labelFoodMoreInfo,
 				type: InputTypes.textarea,
 				name: "meals_info",
+				required: true,
+				valid: true,
 			},
 			{
 				label: labelLinkMenu,
 				type: InputTypes.url,
 				name: "menu_link",
+				required: true,
+				valid: true,
 			},
 		],
 		activitiesFields: [
@@ -343,28 +347,38 @@ const PageUpdate: FC = () => {
 				label: labelActivies,
 				type: InputTypes.textarea,
 				name: "activities_info",
+				required: true,
+				valid: true,
 			},
 			{
 				label: labelLinkMoreInfoActivies,
 				type: InputTypes.url,
 				name: "activities_link",
+				required: true,
+				valid: true,
 			},
 			{
 				label: labelOutdoorActivies,
 				type: InputTypes.textarea,
 				name: "outdoors_possibilities_info",
+				required: true,
+				valid: true,
 			},
 			{
 				label: labelLinkMoreInfoOutdoor,
 				type: InputTypes.url,
 				name: "outdoors_possibilities_link",
+				required: true,
+				valid: true,
 			},
 		],
 		nursingHomeContactFields: [
 			{
-				label: labelVisitingInfo,
+				label: labelContactDescription,
 				type: InputTypes.textarea,
 				name: "tour_info",
+				required: true,
+				valid: true,
 			},
 			{
 				label: labelContactName,
@@ -405,6 +419,8 @@ const PageUpdate: FC = () => {
 				label: labelAccessibility,
 				type: InputTypes.textarea,
 				name: "accessibility_info",
+				required: true,
+				valid: true,
 			},
 		],
 		staffFields: [
@@ -431,6 +447,29 @@ const PageUpdate: FC = () => {
 				label: labelNearbyServices,
 				type: InputTypes.textarea,
 				name: "nearby_services",
+				required: true,
+				valid: true,
+			},
+		],
+		vacancyFields: [
+			{
+				label: intro,
+				type: InputTypes.radio,
+				buttons: [
+					{ value: true, label: labelTrue },
+					{ value: false, label: labelFalse },
+				],
+				name: "has_vacancy",
+				change: (selected: boolean) => {
+					console.log(selected);
+
+					setHasVacancy(selected);
+				},
+			},
+			{
+				label: labelLAHapartments,
+				type: InputTypes.checkbox,
+				name: "lah",
 			},
 		],
 	});
@@ -481,41 +520,41 @@ const PageUpdate: FC = () => {
 		{ name: "owner_logo", remove: false, value: "", text: "" },
 	];
 
-	const nursinghomeImageTypes = [
-		"overview_outside",
-		"apartment",
-		"lounge",
-		"dining_room",
-		"outside",
-		"entrance",
-		"bathroom",
-		"apartment_layout",
-		"nursinghome_layout",
-	];
+	// const nursinghomeImageTypes = [
+	// 	"overview_outside",
+	// 	"apartment",
+	// 	"lounge",
+	// 	"dining_room",
+	// 	"outside",
+	// 	"entrance",
+	// 	"bathroom",
+	// 	"apartment_layout",
+	// 	"nursinghome_layout",
+	// ];
 
-	const removeImage = (id: string): void => {
-		const index = imageState.findIndex(x => x.name === id);
-		imageState[index].remove = true;
-		imageState[index].value = "";
-	};
+	// const removeImage = (id: string): void => {
+	// 	const index = imageState.findIndex(x => x.name === id);
+	// 	imageState[index].remove = true;
+	// 	imageState[index].value = "";
+	// };
 
-	const updateImageState = (id: string, state: string): void => {
-		const index = imageState.findIndex(x => x.name === id);
-		imageState[index].value = state;
-		imageState[index].remove = false;
-	};
+	// const updateImageState = (id: string, state: string): void => {
+	// 	const index = imageState.findIndex(x => x.name === id);
+	// 	imageState[index].value = state;
+	// 	imageState[index].remove = false;
+	// };
 
-	const updateCaptionState = (id: string, state: string): void => {
-		const index = imageState.findIndex(x => x.name === id);
-		imageState[index].text = state;
-	};
+	// const updateCaptionState = (id: string, state: string): void => {
+	// 	const index = imageState.findIndex(x => x.name === id);
+	// 	imageState[index].text = state;
+	// };
 
 	const validForm = (): boolean => {
 		let formIsValid = true;
 
 		Object.keys(form).forEach(section => {
 			const invalidFields =
-				form[section].filter(field => {
+				form[section].filter((field: InputField) => {
 					return field.valid === false;
 				}).length > 0;
 
@@ -555,7 +594,9 @@ const PageUpdate: FC = () => {
 					const formData: any = {};
 
 					fields.forEach(field => {
-						formData[field.name] = nursingHome[field.name];
+						if (field.name !== "has_vacancy") {
+							formData[field.name] = nursingHome[field.name];
+						}
 					});
 
 					const updateNursingHomeData: NursingHomeUpdateData = formData;
@@ -633,7 +674,7 @@ const PageUpdate: FC = () => {
 					return (
 						<div className="field" key={`${field.name}-${index}`}>
 							<label className="label" htmlFor={field.name}>
-								{field.label}
+								{field.label} {field.required ? "*" : ""}
 							</label>
 							<div className="control">
 								<textarea
@@ -697,7 +738,7 @@ const PageUpdate: FC = () => {
 							className="field"
 							key={`${field.name}-${index}`}
 						>
-							<legend>{labelAra}</legend>
+							<legend>{field.label}</legend>
 							{field.buttons
 								? field.buttons.map(button => {
 										return (
@@ -713,6 +754,12 @@ const PageUpdate: FC = () => {
 												}
 												value={button.value}
 												onChange={() => {
+													if (field.change) {
+														field.change(
+															button.value,
+														);
+													}
+
 													handleInputChange(
 														field,
 														button.value,
@@ -730,7 +777,7 @@ const PageUpdate: FC = () => {
 					return (
 						<div className="field" key={`${field.name}-${index}`}>
 							<label className="label" htmlFor={field.name}>
-								{field.label}
+								{field.label} {field.required ? "*" : ""}
 							</label>
 							<div className="control">
 								<input
@@ -835,31 +882,109 @@ const PageUpdate: FC = () => {
 										  ) || noUpdate
 										: loadingText}
 								</p>
-								<p className="page-update-intro">{intro}</p>
 
-								<Radio
-									id="update-vacancy-true"
-									name="update-vacancy-true"
-									isSelected={hasVacancy}
-									onChange={isChecked => {
-										if (isChecked) setHasVacancy(true);
-									}}
-								>
-									{labelTrue}
-								</Radio>
-								<Radio
-									id="update-vacancy-false"
-									name="update-vacancy-false"
-									isSelected={!hasVacancy}
-									onChange={isChecked => {
-										if (isChecked) setHasVacancy(false);
-									}}
-								>
-									{labelFalse}
-								</Radio>
+								<div className="page-update-data">
+									{form.vacancyFields.map((field, index) =>
+										getInputElement(
+											field,
+											"vacancyFields",
+											index,
+										),
+									)}
+								</div>
+								<div className="page-update-data">
+									<Link to={"/"}>Lisää kuvia</Link>
+								</div>
+							</div>
+							<div className="page-update-section">
+								<h3>{labelVisitingInfo}</h3>
+								{form.nursingHomeContactFields.map(
+									(field, index) =>
+										getInputElement(
+											field,
+											"nursingHomeContactFields",
+											index,
+										),
+								)}
+							</div>
+							<div className="page-update-section">
+								<h3>{labelContactInfo}</h3>
+								{form.contactFields.map((field, index) =>
+									getInputElement(
+										field,
+										"contactFields",
+										index,
+									),
+								)}
+							</div>
+							<div className="page-update-section">
+								<h3>{labelBasicInformation}</h3>
+								{form.basicFields.map((field, index) =>
+									getInputElement(
+										field,
+										"basicFields",
+										index,
+									),
+								)}
+							</div>
+							<div className="page-update-section">
+								<h3>{labelNearbyServices}</h3>
+								{form.nearbyServicesFields.map((field, index) =>
+									getInputElement(
+										field,
+										"nearbyServicesFields",
+										index,
+									),
+								)}
+							</div>
+							<div className="page-update-section">
+								<h3>{labelFoodHeader}</h3>
+								{form.foodFields.map((field, index) =>
+									getInputElement(field, "foodFields", index),
+								)}
+							</div>
+							<div className="page-update-section">
+								<h3>{labelActivies}</h3>
+								{form.activitiesFields.map((field, index) =>
+									getInputElement(
+										field,
+										"activitiesFields",
+										index,
+									),
+								)}
+							</div>
+							<div className="page-update-section">
+								<h3>{labelAccessibility}</h3>
+								{form.accessibilityFields.map((field, index) =>
+									getInputElement(
+										field,
+										"accessibilityFields",
+										index,
+									),
+								)}
+							</div>
+							<div className="page-update-section">
+								<h3>{labelPersonnel}</h3>
+								{form.staffFields.map((field, index) =>
+									getInputElement(
+										field,
+										"staffFields",
+										index,
+									),
+								)}
+							</div>
+							<div className="page-update-section">
+								<h3>{labelOtherServices}</h3>
+								{form.otherServicesFields.map((field, index) =>
+									getInputElement(
+										field,
+										"otherServicesFields",
+										index,
+									),
+								)}
 							</div>
 						</form>
-						<div className="page-update-section nursinghome-logo-upload">
+						{/* <div className="page-update-section nursinghome-logo-upload">
 							<h3 className="page-update-minor-title">
 								{organizationLogo}
 							</h3>
@@ -911,81 +1036,7 @@ const PageUpdate: FC = () => {
 									),
 								)}
 							</div>
-						</div>
-						<div className="page-update-section">
-							<h3>{labelBasicInformation}</h3>
-							{form.basicFields.map((field, index) =>
-								getInputElement(field, "basicFields", index),
-							)}
-						</div>
-						<div className="page-update-section">
-							<h3>{labelContactInfo}</h3>
-							{form.contactFields.map((field, index) =>
-								getInputElement(field, "contactFields", index),
-							)}
-						</div>
-						<div className="page-update-section">
-							<h3>{labelFoodHeader}</h3>
-							{form.foodFields.map((field, index) =>
-								getInputElement(field, "foodFields", index),
-							)}
-						</div>
-						<div className="page-update-section">
-							<h3>{labelActivies}</h3>
-							{form.activitiesFields.map((field, index) =>
-								getInputElement(
-									field,
-									"activitiesFields",
-									index,
-								),
-							)}
-						</div>
-						<div className="page-update-section">
-							<h3>{labelVisitingInfo}</h3>
-							{form.nursingHomeContactFields.map((field, index) =>
-								getInputElement(
-									field,
-									"nursingHomeContactFields",
-									index,
-								),
-							)}
-						</div>
-						<div className="page-update-section">
-							<h3>{labelAccessibility}</h3>
-							{form.accessibilityFields.map((field, index) =>
-								getInputElement(
-									field,
-									"accessibilityFields",
-									index,
-								),
-							)}
-						</div>
-						<div className="page-update-section">
-							<h3>{labelPersonnel}</h3>
-							{form.staffFields.map((field, index) =>
-								getInputElement(field, "staffFields", index),
-							)}
-						</div>
-						<div className="page-update-section">
-							<h3>{labelOtherServices}</h3>
-							{form.otherServicesFields.map((field, index) =>
-								getInputElement(
-									field,
-									"otherServicesFields",
-									index,
-								),
-							)}
-						</div>
-						<div className="page-update-section">
-							<h3>{labelNearbyServices}</h3>
-							{form.nearbyServicesFields.map((field, index) =>
-								getInputElement(
-									field,
-									"nearbyServicesFields",
-									index,
-								),
-							)}
-						</div>
+						</div> */}
 					</>
 				)}
 			</div>

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { ChangeEvent, FC, useEffect, useState } from "react";
 import { useT } from "../i18n";
 import "../styles/PageUpdate.scss";
 import Radio from "./Radio";
@@ -495,9 +495,25 @@ const PageUpdate: FC = () => {
 		window.location.href = window.location.pathname + "/peruuta";
 	};
 
-	const handleInputChange = (key: string, value: string | boolean) => {
+	const handleInputChange = (
+		key: string,
+		data:
+			| ChangeEvent<HTMLInputElement>
+			| ChangeEvent<HTMLTextAreaElement>
+			| boolean,
+	) => {
 		if (nursingHome) {
-			setNursingHome({ ...nursingHome, [key]: value });
+			if (typeof data === "boolean") {
+				setNursingHome({ ...nursingHome, [key]: data });
+			} else {
+				const { value, type } = data.target;
+
+				if (type === "number") {
+					setNursingHome({ ...nursingHome, [key]: parseInt(value) });
+				} else {
+					setNursingHome({ ...nursingHome, [key]: value });
+				}
+			}
 		}
 	};
 
@@ -513,9 +529,7 @@ const PageUpdate: FC = () => {
 						value={(field.value as string) || ""}
 						name={field.name}
 						id={field.name}
-						onChange={event =>
-							handleInputChange(field.name, event.target.value)
-						}
+						onChange={event => handleInputChange(field.name, event)}
 					></textarea>
 				</div>
 			);
@@ -544,13 +558,11 @@ const PageUpdate: FC = () => {
 				>
 					<label htmlFor={field.name}>{field.label}</label>
 					<input
-						value={(field.value as string) || ""}
+						value={(field.value as string | number) || ""}
 						name={field.name}
 						id={field.name}
 						type={field.type}
-						onChange={event =>
-							handleInputChange(field.name, event.target.value)
-						}
+						onChange={event => handleInputChange(field.name, event)}
 					/>
 				</div>
 			);

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -27,6 +27,14 @@ interface InputField {
 	value: string | number | boolean | undefined;
 }
 
+enum InputTypes {
+	text = "text",
+	textarea = "textarea",
+	number = "number",
+	checkbox = "checkbox",
+	email = "email",
+}
+
 const formatDate = (dateString: string | null): string => {
 	if (!dateString) return "";
 	const date = new Date(dateString);
@@ -134,6 +142,51 @@ const PageUpdate: FC = () => {
 		"nursinghome_layout",
 	];
 
+	const title = useT("pageUpdateTitle");
+	const freeApartmentsStatus = useT("freeApartmentsStatus");
+	const organizationLogo = useT("organizationLogo");
+	const organizationPhotos = useT("organizationPhotos");
+	const organizationPhotosGuide = useT("organizationPhotosGuide");
+	const intro = useT("pageUpdateIntro");
+	const labelTrue = useT("vacancyTrue");
+	const labelFalse = useT("vacancyFalse");
+	const loadingText = useT("loadingText");
+	const nursingHomeName = useT("nursingHome");
+	const status = useT("status");
+	const lastUpdate = useT("lastUpdate");
+	const noUpdate = useT("noUpdate");
+	const btnSave = useT("btnSave");
+	const cancel = useT("cancel");
+
+	const textOwner = useT("owner");
+	const textAra = useT("filterAraLabel");
+	const textYearofConst = useT("yearofConst");
+	const textNumApartments = useT("numApartments");
+	const textApartmentSize = useT("apartmentSize");
+	const textRent = useT("rent");
+	const textServiceLanguage = useT("serviceLanguage");
+	const textLAHapartments = useT("LAHapartments");
+	const textWebpage = useT("webpage");
+	const textCookingMethod = useT("cookingMethod");
+	const textFoodMoreInfo = useT("foodMoreInfo");
+	const textLinkMenu = useT("linkMenu");
+	const textActivies = useT("activies");
+	const textLinkMoreInfoActivies = useT("linkMoreInfoActivies");
+	const textOutdoorActivies = useT("outdoorActivies");
+	const textLinkMoreInfoOutdoor = useT("linkMoreInfoOutdoor");
+	const textVisitingInfo = useT("visitingInfo");
+	const textAccessibility = useT("accessibility");
+	const textPersonnel = useT("personnel");
+	const textLinkMoreInfoPersonnel = useT("linkMoreInfoPersonnel");
+	const textOtherServices = useT("otherServices");
+	const textNearbyServices = useT("nearbyServices");
+	const textBasicInformation = useT("basicInformation");
+	const textContactInfo = useT("contactInfo");
+	const textFoodHeader = useT("foodHeader");
+
+	const updatePopupSaved = useT("saved");
+	const updatePopupSaving = useT("saving");
+
 	let basicFields: InputField[] = [];
 	let contactFields: InputField[] = [];
 	let foodFields: InputField[] = [];
@@ -148,85 +201,85 @@ const PageUpdate: FC = () => {
 		basicFields = [
 			{
 				label: "Yhteenveto",
-				type: "textarea",
+				type: InputTypes.textarea,
 				name: "summary",
 				value: nursingHome.summary ? nursingHome.summary : "",
 			},
 			{
-				label: "Omistaja",
-				type: "text",
+				label: textOwner,
+				type: InputTypes.text,
 				name: "owner",
 				value: nursingHome.owner,
 			},
 			{
-				label: "ARA-kohde",
-				type: "checkbox",
+				label: textAra,
+				type: InputTypes.checkbox,
 				name: "ara",
 				value: nursingHome.ara === "Kyllä",
 			},
 			{
-				label: "Rakennusvuosi",
-				type: "text",
+				label: textYearofConst,
+				type: InputTypes.text,
 				name: "construction_year",
 				value: nursingHome.construction_year,
 			},
 			{
-				label: "Tietoja rakennuksesta",
-				type: "textarea",
+				label: "Lisätietoja rakennuksesta",
+				type: InputTypes.textarea,
 				name: "building_info",
 				value: nursingHome.building_info,
 			},
 			{
-				label: "Asuntojen määrä",
-				type: "number",
+				label: textNumApartments,
+				type: InputTypes.number,
 				name: "apartment_count",
 				value: nursingHome.apartment_count,
 			},
 			{
-				label: "Asuntojen määrä, lisätietoja",
-				type: "textarea",
+				label: "Lisätietoja asuntojen määrästä",
+				type: InputTypes.textarea,
 				name: "apartment_count_info",
 				value: nursingHome.apartment_count_info,
 			},
 			{
-				label: "Asuntojen neliömäärä",
-				type: "text",
+				label: textApartmentSize,
+				type: InputTypes.text,
 				name: "apartment_square_meters",
 				value: nursingHome.apartment_square_meters,
 			},
 			{
 				label: "Asunnoissa oma kylpyhuone",
-				type: "checkbox",
+				type: InputTypes.checkbox,
 				name: "apartments_have_bathroom",
 				value: nursingHome.apartments_have_bathroom,
 			},
 			{
-				label: "Vuokran määrä",
-				type: "text",
+				label: textRent,
+				type: InputTypes.text,
 				name: "rent",
 				value: nursingHome.rent,
 			},
 			{
-				label: "Vuokra lisätietoja",
-				type: "textarea",
+				label: "Lisätietoja vuokrasta",
+				type: InputTypes.textarea,
 				name: "rent_info",
 				value: nursingHome.rent_info,
 			},
 			{
-				label: "Palvelukieli",
-				type: "text",
+				label: textServiceLanguage,
+				type: InputTypes.text,
 				name: "language",
 				value: nursingHome.language,
 			},
 			{
-				label: "Palvelukieli lisätietoja",
-				type: "textarea",
+				label: "Lisätietoja palvelukielestä",
+				type: InputTypes.textarea,
 				name: "language_info",
 				value: nursingHome.language_info,
 			},
 			{
-				label: "Lyhytaikaisen asumisen asuntoja",
-				type: "checkbox",
+				label: textLAHapartments,
+				type: InputTypes.checkbox,
 				name: "lah",
 				value: nursingHome.lah,
 			},
@@ -235,37 +288,37 @@ const PageUpdate: FC = () => {
 		contactFields = [
 			{
 				label: "Katuosoite",
-				type: "text",
+				type: InputTypes.text,
 				name: "address",
 				value: nursingHome.address,
 			},
 			{
 				label: "Postinumero",
-				type: "text",
+				type: InputTypes.text,
 				name: "postal_code",
 				value: nursingHome.postal_code,
 			},
 			{
 				label: "Kaupunki",
-				type: "text",
+				type: InputTypes.text,
 				name: "city",
 				value: nursingHome.city,
 			},
 			{
 				label: "Kaupunginosa",
-				type: "text",
+				type: InputTypes.text,
 				name: "district",
 				value: nursingHome.district,
 			},
 			{
-				label: "Verkkosivut",
-				type: "text",
+				label: textWebpage,
+				type: InputTypes.text,
 				name: "www",
 				value: nursingHome.www,
 			},
 			{
 				label: "Saapuminen julkisilla kulkuyhteyksillä",
-				type: "textarea",
+				type: InputTypes.textarea,
 				name: "arrival_guide_public_transit",
 				value: nursingHome.arrival_guide_public_transit
 					? nursingHome.arrival_guide_public_transit
@@ -273,7 +326,7 @@ const PageUpdate: FC = () => {
 			},
 			{
 				label: "Saapuminen autolla",
-				type: "textarea",
+				type: InputTypes.textarea,
 				name: "arrival_guide_car",
 				value: nursingHome.arrival_guide_car
 					? nursingHome.arrival_guide_car
@@ -283,20 +336,20 @@ const PageUpdate: FC = () => {
 
 		foodFields = [
 			{
-				label: "Ruoan valmistuksen tapa",
-				type: "text",
+				label: textCookingMethod,
+				type: InputTypes.text,
 				name: "meals_preparation",
 				value: nursingHome.meals_preparation,
 			},
 			{
-				label: "Lisätietoa ruoasta",
-				type: "textarea",
+				label: textFoodMoreInfo,
+				type: InputTypes.textarea,
 				name: "meals_info",
 				value: nursingHome.meals_info ? nursingHome.meals_info : "",
 			},
 			{
-				label: "Ruokalista (linkki)",
-				type: "text",
+				label: textLinkMenu,
+				type: InputTypes.text,
 				name: "menu_link",
 				value: nursingHome.menu_link,
 			},
@@ -304,28 +357,28 @@ const PageUpdate: FC = () => {
 
 		activitiesFields = [
 			{
-				label: "Aktiviteetit",
-				type: "textarea",
+				label: textActivies,
+				type: InputTypes.textarea,
 				name: "activities_info",
 				value: nursingHome.activities_info
 					? nursingHome.activities_info
 					: "",
 			},
 			{
-				label: "Aktiviteetit (linkki)",
-				type: "text",
+				label: textLinkMoreInfoActivies,
+				type: InputTypes.text,
 				name: "activities_link",
 				value: nursingHome.activities_link,
 			},
 			{
-				label: "Ulkoilumahdollisuudet",
-				type: "textarea",
+				label: textOutdoorActivies,
+				type: InputTypes.textarea,
 				name: "outdoors_possibilities_info",
 				value: nursingHome.outdoors_possibilities_info,
 			},
 			{
-				label: "Ulkoilumahdollisuudet (linkki)",
-				type: "text",
+				label: textLinkMoreInfoOutdoor,
+				type: InputTypes.text,
 				name: "outdoors_possibilities_link",
 				value: nursingHome.outdoors_possibilities_link,
 			},
@@ -333,38 +386,38 @@ const PageUpdate: FC = () => {
 
 		nursingHomeContactFields = [
 			{
-				label: "Tutustuminen",
-				type: "textarea",
+				label: textVisitingInfo,
+				type: InputTypes.textarea,
 				name: "tour_info",
 				value: nursingHome.tour_info ? nursingHome.tour_info : "",
 			},
 			{
 				label: "Yhteyshenkilön nimi",
-				type: "text",
+				type: InputTypes.text,
 				name: "contact_name",
 				value: nursingHome.contact_name,
 			},
 			{
 				label: "Yhteyshenkilön titteli",
-				type: "text",
+				type: InputTypes.text,
 				name: "contact_title",
 				value: nursingHome.contact_title,
 			},
 			{
-				label: "Yhteyshenkilön puh.",
-				type: "text",
+				label: "Yhteyshenkilön puhelinnumero",
+				type: InputTypes.text,
 				name: "contact_phone",
 				value: nursingHome.contact_phone,
 			},
 			{
 				label: "Yhteyshenkilön sähköposti",
-				type: "email",
+				type: InputTypes.email,
 				name: "email",
 				value: nursingHome.email,
 			},
 			{
-				label: "Yhteyshenkilön puh. info",
-				type: "text",
+				label: "Lisätietoja yhteyshenkilön puhelinnumerosta",
+				type: InputTypes.text,
 				name: "contact_phone_info",
 				value: nursingHome.contact_phone_info,
 			},
@@ -372,8 +425,8 @@ const PageUpdate: FC = () => {
 
 		accessibilityFields = [
 			{
-				label: "Esteettömyys info",
-				type: "textarea",
+				label: textAccessibility,
+				type: InputTypes.textarea,
 				name: "accessibility_info",
 				value: nursingHome.accessibility_info
 					? nursingHome.accessibility_info
@@ -383,14 +436,14 @@ const PageUpdate: FC = () => {
 
 		staffFields = [
 			{
-				label: "Henkilökunta info",
-				type: "textarea",
+				label: textPersonnel,
+				type: InputTypes.textarea,
 				name: "staff_info",
 				value: nursingHome.staff_info ? nursingHome.staff_info : "",
 			},
 			{
-				label: "Lisätietoja henkilöstön tyytyväisyydestä (linkki)",
-				type: "text",
+				label: textLinkMoreInfoPersonnel,
+				type: InputTypes.text,
 				name: "staff_satisfaction_info",
 				value: nursingHome.staff_satisfaction_info,
 			},
@@ -398,8 +451,8 @@ const PageUpdate: FC = () => {
 
 		otherServicesFields = [
 			{
-				label: "Muut palvelut",
-				type: "textarea",
+				label: textOtherServices,
+				type: InputTypes.textarea,
 				name: "other_services",
 				value: nursingHome.other_services
 					? nursingHome.other_services
@@ -409,8 +462,8 @@ const PageUpdate: FC = () => {
 
 		nearbyServicesFields = [
 			{
-				label: "Lähellä olevat palvelut",
-				type: "textarea",
+				label: textNearbyServices,
+				type: InputTypes.textarea,
 				name: "nearby_services",
 				value: nursingHome.nearby_services
 					? nursingHome.nearby_services
@@ -435,25 +488,6 @@ const PageUpdate: FC = () => {
 		const index = imageState.findIndex(x => x.name === id);
 		imageState[index].text = state;
 	};
-
-	const title = useT("pageUpdateTitle");
-	const freeApartmentsStatus = useT("freeApartmentsStatus");
-	const organizationLogo = useT("organizationLogo");
-	const organizationPhotos = useT("organizationPhotos");
-	const organizationPhotosGuide = useT("organizationPhotosGuide");
-	const intro = useT("pageUpdateIntro");
-	const labelTrue = useT("vacancyTrue");
-	const labelFalse = useT("vacancyFalse");
-	const loadingText = useT("loadingText");
-	const nursingHomeName = useT("nursingHome");
-	const status = useT("status");
-	const lastUpdate = useT("lastUpdate");
-	const noUpdate = useT("noUpdate");
-	const btnSave = useT("btnSave");
-	const cancel = useT("cancel");
-
-	const updatePopupSaved = useT("saved");
-	const updatePopupSaving = useT("saving");
 
 	const handleSubmit = async (
 		e: React.FormEvent<HTMLFormElement>,
@@ -653,13 +687,13 @@ const PageUpdate: FC = () => {
 							</div>
 						</div>
 						<div className="page-update-section">
-							<h3>Perustiedot</h3>
+							<h3>{textBasicInformation}</h3>
 							{basicFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>Yhteystiedot</h3>
+							<h3>{textContactInfo}</h3>
 							{contactFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
@@ -671,37 +705,37 @@ const PageUpdate: FC = () => {
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>Toiminta</h3>
+							<h3>{textFoodHeader}</h3>
 							{activitiesFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>Hoivakotiin tutustuminen</h3>
+							<h3>{textVisitingInfo}</h3>
 							{nursingHomeContactFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>Esteettömyys</h3>
+							<h3>{textAccessibility}</h3>
 							{accessibilityFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>Henkilökunta</h3>
+							<h3>{textPersonnel}</h3>
 							{staffFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>Muut hoivakodin palvelut</h3>
+							<h3>{textOtherServices}</h3>
 							{otherServicesFields.map((field, index) =>
 								getInputElement(field, index),
 							)}
 						</div>
 						<div className="page-update-section">
-							<h3>Lähellä olevat palvelut</h3>
+							<h3>{textNearbyServices}</h3>
 							{nearbyServicesFields.map((field, index) =>
 								getInputElement(field, index),
 							)}

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -198,6 +198,9 @@ const PageUpdate: FC = () => {
 	const filterFinnish = useT("filterFinnish");
 	const filterSwedish = useT("filterSwedish");
 	const nearbyServices = useT("nearbyServices");
+	const fieldsWithAsteriskAreMandatory = useT(
+		"fieldsWithAsteriskAreMandatory",
+	);
 
 	if (!id || !key) throw new Error("Invalid URL!");
 
@@ -774,7 +777,11 @@ const PageUpdate: FC = () => {
 				case "textarea":
 					return (
 						<div className="field" key={key}>
-							<label className="label" htmlFor={field.name}>
+							<label
+								id={`${field.name}-label`}
+								className="label"
+								htmlFor={field.name}
+							>
 								{field.label}
 								{field.required ? (
 									<span
@@ -787,7 +794,10 @@ const PageUpdate: FC = () => {
 								) : null}
 							</label>
 							{field.description ? (
-								<span className="input-description">
+								<span
+									id={`${field.name}-description`}
+									className="input-description"
+								>
 									{field.description}
 								</span>
 							) : null}
@@ -811,6 +821,11 @@ const PageUpdate: FC = () => {
 									required={field.required}
 									aria-required={field.required}
 									onBlur={validateForm}
+									aria-labelledby={
+										field.description
+											? `${field.name}-label ${field.name}-description`
+											: undefined
+									}
 								></textarea>
 								{fieldInvalid ? (
 									<span className="icon"></span>
@@ -980,7 +995,11 @@ const PageUpdate: FC = () => {
 				default:
 					return (
 						<div className="field" key={key}>
-							<label className="label" htmlFor={field.name}>
+							<label
+								id={`${field.name}-label`}
+								className="label"
+								htmlFor={field.name}
+							>
 								{field.label}
 								{field.required ? (
 									<span
@@ -993,7 +1012,10 @@ const PageUpdate: FC = () => {
 								) : null}
 							</label>
 							{field.description ? (
-								<span className="input-description">
+								<span
+									id={`${field.name}-description`}
+									className="input-description"
+								>
 									{field.description}
 								</span>
 							) : null}
@@ -1016,6 +1038,11 @@ const PageUpdate: FC = () => {
 									onBlur={validateForm}
 									required={field.required}
 									aria-required={field.required}
+									aria-labelledby={
+										field.description
+											? `${field.name}-label ${field.name}-description`
+											: undefined
+									}
 								/>
 								{fieldInvalid ? (
 									<span className="icon"></span>
@@ -1051,37 +1078,9 @@ const PageUpdate: FC = () => {
 							className="page-update-controls"
 							onSubmit={handleSubmit}
 						>
-							<div className="nav-save">
-								<button
-									className="page-update-cancel"
-									onClick={cancelEdit}
-								>
-									{cancel}
-								</button>
-								<button
-									type="submit"
-									className="btn page-update-submit"
-									disabled={!formIsValid}
-								>
-									{btnSave}
-								</button>
-
-								{popupState && (
-									<span
-										className={
-											popupState === "invalid"
-												? "page-update-popup error"
-												: "page-update-popup"
-										}
-									>
-										{popupState === "saving"
-											? updatePopupSaving
-											: popupState === "invalid"
-											? formIsInvalid
-											: updatePopupSaved}
-									</span>
-								)}
-							</div>
+							<p className="page-update-info" aria-hidden="true">
+								{fieldsWithAsteriskAreMandatory}
+							</p>
 							<div className="page-update-section">
 								<h3>{freeApartmentsStatus}</h3>
 								{form.vacancyFields.map((field, index) =>
@@ -1193,6 +1192,37 @@ const PageUpdate: FC = () => {
 										"nearbyServicesFields",
 										index,
 									),
+								)}
+							</div>
+							<div className="nav-save">
+								<button
+									className="page-update-cancel"
+									onClick={cancelEdit}
+								>
+									{cancel}
+								</button>
+								<button
+									type="submit"
+									className="btn page-update-submit"
+									disabled={!formIsValid}
+								>
+									{btnSave}
+								</button>
+
+								{popupState && (
+									<span
+										className={
+											popupState === "invalid"
+												? "page-update-popup error"
+												: "page-update-popup"
+										}
+									>
+										{popupState === "saving"
+											? updatePopupSaving
+											: popupState === "invalid"
+											? formIsInvalid
+											: updatePopupSaved}
+									</span>
 								)}
 							</div>
 						</form>

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -7,7 +7,7 @@ import { useParams } from "react-router-dom";
 import axios from "axios";
 import config from "./config";
 import { GetNursingHomeResponse } from "./PageNursingHome";
-import { NursingHome, NursingHomeImageName, OptionalProps } from "./types";
+import { NursingHome, NursingHomeImageName } from "./types";
 import Checkbox from "./Checkbox";
 
 enum InputTypes {
@@ -31,8 +31,6 @@ interface NursingHomeRouteParams {
 	key: string;
 }
 
-type NursingHomeKey = keyof NursingHome;
-
 interface InputField {
 	label: string;
 	type: InputTypes;
@@ -42,17 +40,7 @@ interface InputField {
 	valid?: boolean;
 }
 
-type TransformableNursingHome = OptionalProps<
-	NursingHome,
-	| "id"
-	| "pic_digests"
-	| "pics"
-	| "pic_captions"
-	| "report_status"
-	| "rating"
-	| "geolocation"
-	| "has_vacancy"
->;
+type NursingHomeKey = keyof NursingHome;
 
 type NursingHomeUpdateData = Omit<
 	NursingHome,
@@ -132,80 +120,6 @@ const PageUpdate: FC = () => {
 	>(null);
 	const [hasVacancy, setHasVacancy] = useState<boolean>(false);
 
-	if (!id || !key) throw new Error("Invalid URL!");
-
-	useEffect(() => {
-		axios
-			.get(`${config.API_URL}/nursing-homes/${id}`)
-			.then((response: GetNursingHomeResponse) => {
-				setNursingHome(response.data);
-			})
-			.catch(e => {
-				console.error(e);
-				throw e;
-			});
-	}, [id]);
-
-	useEffect(() => {
-		if (!vacancyStatus) {
-			axios
-				.get(
-					`${config.API_URL}/nursing-homes/${id}/vacancy-status/${key}`,
-				)
-				.then((response: { data: VacancyStatus }) => {
-					setVacancyStatus(response.data);
-					setHasVacancy(response.data.has_vacancy);
-
-					if (popupState) setTimeout(() => setPopupState(null), 3000);
-				})
-				.catch(e => {
-					console.error(e);
-					throw e;
-				});
-		}
-	}, [id, key, popupState, vacancyStatus]);
-
-	const imageState = [
-		{ name: "overview_outside", remove: false, value: "", text: "" },
-		{ name: "apartment", remove: false, value: "", text: "" },
-		{ name: "lounge", remove: false, value: "", text: "" },
-		{ name: "dining_room", remove: false, value: "", text: "" },
-		{ name: "outside", remove: false, value: "", text: "" },
-		{ name: "entrance", remove: false, value: "", text: "" },
-		{ name: "bathroom", remove: false, value: "", text: "" },
-		{ name: "apartment_layout", remove: false, value: "", text: "" },
-		{ name: "nursinghome_layout", remove: false, value: "", text: "" },
-		{ name: "owner_logo", remove: false, value: "", text: "" },
-	];
-
-	const nursinghomeImageTypes = [
-		"overview_outside",
-		"apartment",
-		"lounge",
-		"dining_room",
-		"outside",
-		"entrance",
-		"bathroom",
-		"apartment_layout",
-		"nursinghome_layout",
-	];
-
-	const title = useT("pageUpdateTitle");
-	const freeApartmentsStatus = useT("freeApartmentsStatus");
-	const organizationLogo = useT("organizationLogo");
-	const organizationPhotos = useT("organizationPhotos");
-	const organizationPhotosGuide = useT("organizationPhotosGuide");
-	const intro = useT("pageUpdateIntro");
-	const labelTrue = useT("vacancyTrue");
-	const labelFalse = useT("vacancyFalse");
-	const loadingText = useT("loadingText");
-	const nursingHomeName = useT("nursingHome");
-	const status = useT("status");
-	const lastUpdate = useT("lastUpdate");
-	const noUpdate = useT("noUpdate");
-	const btnSave = useT("btnSave");
-	const cancel = useT("cancel");
-
 	const labelOwner = useT("owner");
 	const labelAra = useT("filterAraLabel");
 	const labelYearofConst = useT("yearofConst");
@@ -250,11 +164,6 @@ const PageUpdate: FC = () => {
 	const labelContactPhone = useT("contactPhone");
 	const labelContactEmail = useT("contactEmail");
 	const labelContactPhoneInfo = useT("contactPhoneInfo");
-	const textFieldIsRequired = useT("fieldIsRequired");
-
-	const updatePopupSaved = useT("saved");
-	const updatePopupSaving = useT("saving");
-	const formIsInvalid = useT("formIsInvalid");
 
 	const [form, setForm] = useState<{ [key: string]: InputField[] }>({
 		basicFields: [
@@ -507,6 +416,84 @@ const PageUpdate: FC = () => {
 		],
 	});
 
+	if (!id || !key) throw new Error("Invalid URL!");
+
+	useEffect(() => {
+		axios
+			.get(`${config.API_URL}/nursing-homes/${id}`)
+			.then((response: GetNursingHomeResponse) => {
+				setNursingHome(response.data);
+			})
+			.catch(e => {
+				console.error(e);
+				throw e;
+			});
+	}, [id]);
+
+	useEffect(() => {
+		if (!vacancyStatus) {
+			axios
+				.get(
+					`${config.API_URL}/nursing-homes/${id}/vacancy-status/${key}`,
+				)
+				.then((response: { data: VacancyStatus }) => {
+					setVacancyStatus(response.data);
+					setHasVacancy(response.data.has_vacancy);
+
+					if (popupState) setTimeout(() => setPopupState(null), 3000);
+				})
+				.catch(e => {
+					console.error(e);
+					throw e;
+				});
+		}
+	}, [id, key, popupState, vacancyStatus]);
+
+	const imageState = [
+		{ name: "overview_outside", remove: false, value: "", text: "" },
+		{ name: "apartment", remove: false, value: "", text: "" },
+		{ name: "lounge", remove: false, value: "", text: "" },
+		{ name: "dining_room", remove: false, value: "", text: "" },
+		{ name: "outside", remove: false, value: "", text: "" },
+		{ name: "entrance", remove: false, value: "", text: "" },
+		{ name: "bathroom", remove: false, value: "", text: "" },
+		{ name: "apartment_layout", remove: false, value: "", text: "" },
+		{ name: "nursinghome_layout", remove: false, value: "", text: "" },
+		{ name: "owner_logo", remove: false, value: "", text: "" },
+	];
+
+	const nursinghomeImageTypes = [
+		"overview_outside",
+		"apartment",
+		"lounge",
+		"dining_room",
+		"outside",
+		"entrance",
+		"bathroom",
+		"apartment_layout",
+		"nursinghome_layout",
+	];
+
+	const title = useT("pageUpdateTitle");
+	const freeApartmentsStatus = useT("freeApartmentsStatus");
+	const organizationLogo = useT("organizationLogo");
+	const organizationPhotos = useT("organizationPhotos");
+	const organizationPhotosGuide = useT("organizationPhotosGuide");
+	const intro = useT("pageUpdateIntro");
+	const labelTrue = useT("vacancyTrue");
+	const labelFalse = useT("vacancyFalse");
+	const loadingText = useT("loadingText");
+	const nursingHomeName = useT("nursingHome");
+	const status = useT("status");
+	const lastUpdate = useT("lastUpdate");
+	const noUpdate = useT("noUpdate");
+	const btnSave = useT("btnSave");
+	const cancel = useT("cancel");
+	const textFieldIsRequired = useT("fieldIsRequired");
+	const updatePopupSaved = useT("saved");
+	const updatePopupSaving = useT("saving");
+	const formIsInvalid = useT("formIsInvalid");
+
 	const removeImage = (id: string): void => {
 		const index = imageState.findIndex(x => x.name === id);
 		imageState[index].remove = true;
@@ -558,25 +545,26 @@ const PageUpdate: FC = () => {
 				);
 
 				if (nursingHome) {
-					const transformNursingHomeData: TransformableNursingHome = {
-						...nursingHome,
-					};
+					let fields: InputField[] = [];
 
-					delete transformNursingHomeData.id;
-					delete transformNursingHomeData.pic_digests;
-					delete transformNursingHomeData.pics;
-					delete transformNursingHomeData.pic_captions;
-					delete transformNursingHomeData.report_status;
-					delete transformNursingHomeData.rating;
-					delete transformNursingHomeData.geolocation;
-					delete transformNursingHomeData.has_vacancy;
+					Object.keys(form)
+						.map(section => form[section])
+						.forEach(section => {
+							fields = [...fields, ...section];
+						});
 
-					const nursingHomeUpdateData: NursingHomeUpdateData = transformNursingHomeData;
+					const formData: any = {};
+
+					fields.forEach(field => {
+						formData[field.name] = nursingHome[field.name];
+					});
+
+					const updateNursingHomeData: NursingHomeUpdateData = formData;
 
 					await requestNursingHomeUpdate(
 						id,
 						key,
-						nursingHomeUpdateData,
+						updateNursingHomeData,
 					);
 				}
 
@@ -608,10 +596,11 @@ const PageUpdate: FC = () => {
 		const { name, required } = field;
 
 		if (required) {
-			const fieldIsValid = validateField(value);
+			const validField = validateField(value);
+
 			let updatedSection;
 
-			if (!fieldIsValid) {
+			if (!validField) {
 				updatedSection = [...form[section]].map(input => {
 					if (input.name === name) {
 						return {
@@ -664,129 +653,142 @@ const PageUpdate: FC = () => {
 		index: number,
 	): JSX.Element | null => {
 		if (nursingHome) {
-			if (field.type === "textarea") {
-				return (
-					<div className="field" key={`${field.name}-${index}`}>
-						<label htmlFor={field.name}>{field.label}</label>
-						<div className="control">
-							<textarea
-								className={
-									field.required && !field.valid
-										? "error"
-										: ""
-								}
-								rows={5}
-								value={
-									(nursingHome[field.name] as string) || ""
-								}
-								name={field.name}
-								id={field.name}
-								onChange={event =>
-									handleInputChange(field, event.target.value)
-								}
-								required={field.required}
-								onBlur={event =>
-									handleInputBlur(
-										field,
-										section,
-										event.target.value,
-									)
-								}
-							></textarea>
+			switch (field.type) {
+				case "textarea":
+					return (
+						<div className="field" key={`${field.name}-${index}`}>
+							<label htmlFor={field.name}>{field.label}</label>
+							<div className="control">
+								<textarea
+									className={
+										field.required && !field.valid
+											? "error"
+											: ""
+									}
+									rows={5}
+									value={
+										(nursingHome[field.name] as string) ||
+										""
+									}
+									name={field.name}
+									id={field.name}
+									onChange={event =>
+										handleInputChange(
+											field,
+											event.target.value,
+										)
+									}
+									required={field.required}
+									onBlur={event =>
+										handleInputBlur(
+											field,
+											section,
+											event.target.value,
+										)
+									}
+								></textarea>
+								{field.required && !field.valid ? (
+									<span className="icon"></span>
+								) : null}
+							</div>
 							{field.required && !field.valid ? (
-								<span className="icon"></span>
+								<p className="help">{textFieldIsRequired}</p>
 							) : null}
 						</div>
-						{field.required && !field.valid ? (
-							<p className="help">{textFieldIsRequired}</p>
-						) : null}
-					</div>
-				);
-			} else if (field.type === "checkbox") {
-				return (
-					<div className="field" key={`${field.name}-${index}`}>
-						<Checkbox
-							name={field.name}
-							id={field.name}
-							onChange={checked =>
-								handleInputChange(field, checked)
-							}
-							isChecked={
-								(nursingHome[field.name] as boolean) || false
-							}
+					);
+				case "checkbox":
+					return (
+						<div className="field" key={`${field.name}-${index}`}>
+							<Checkbox
+								name={field.name}
+								id={field.name}
+								onChange={checked =>
+									handleInputChange(field, checked)
+								}
+								isChecked={
+									(nursingHome[field.name] as boolean) ||
+									false
+								}
+							>
+								{field.label}
+							</Checkbox>
+						</div>
+					);
+				case "radio":
+					return (
+						<fieldset
+							className="field"
+							key={`${field.name}-${index}`}
 						>
-							{field.label}
-						</Checkbox>
-					</div>
-				);
-			} else if (field.type === "radio") {
-				return (
-					<fieldset className="field" key={`${field.name}-${index}`}>
-						<legend>{labelAra}</legend>
-						{field.buttons
-							? field.buttons.map(button => {
-									return (
-										<Radio
-											key={`${field.name}-${button.value}`}
-											id={`${field.name}-${button.value}`}
-											name={field.name}
-											isSelected={
-												(nursingHome[
-													field.name
-												] as string) === button.value
-											}
-											value={button.value}
-											onChange={isChecked => {
-												if (isChecked) {
-													handleInputChange(
-														field,
-														button.value,
-													);
+							<legend>{labelAra}</legend>
+							{field.buttons
+								? field.buttons.map(button => {
+										return (
+											<Radio
+												key={`${field.name}-${button.value}`}
+												id={`${field.name}-${button.value}`}
+												name={field.name}
+												isSelected={
+													(nursingHome[
+														field.name
+													] as string) ===
+													button.value
 												}
-											}}
-										>
-											{button.label}
-										</Radio>
-									);
-							  })
-							: null}
-					</fieldset>
-				);
-			} else {
-				return (
-					<div className="field" key={`${field.name}-${index}`}>
-						<label htmlFor={field.name}>{field.label}</label>
-						<div className="control">
-							<input
-								className={
-									field.required && !field.valid
-										? "error"
-										: ""
-								}
-								value={nursingHome[field.name] as string}
-								name={field.name}
-								id={field.name}
-								type={field.type}
-								onChange={event =>
-									handleInputChange(field, event.target.value)
-								}
-								onBlur={event =>
-									handleInputBlur(
-										field,
-										section,
-										event.target.value,
-									)
-								}
-							/>
+												value={button.value}
+												onChange={isChecked => {
+													if (isChecked) {
+														handleInputChange(
+															field,
+															button.value,
+														);
+													}
+												}}
+											>
+												{button.label}
+											</Radio>
+										);
+								  })
+								: null}
+						</fieldset>
+					);
+				default:
+					return (
+						<div className="field" key={`${field.name}-${index}`}>
+							<label htmlFor={field.name}>{field.label}</label>
+							<div className="control">
+								<input
+									className={
+										field.required && !field.valid
+											? "error"
+											: ""
+									}
+									value={nursingHome[field.name] as string}
+									name={field.name}
+									id={field.name}
+									type={field.type}
+									onChange={event =>
+										handleInputChange(
+											field,
+											event.target.value,
+										)
+									}
+									onBlur={event =>
+										handleInputBlur(
+											field,
+											section,
+											event.target.value,
+										)
+									}
+								/>
+								{field.required && !field.valid ? (
+									<span className="icon"></span>
+								) : null}
+							</div>
 							{field.required && !field.valid ? (
-								<span className="icon"></span>
+								<p className="help">{textFieldIsRequired}</p>
 							) : null}
 						</div>
-						{field.required && !field.valid ? (
-							<p className="help">{textFieldIsRequired}</p>
-						) : null}
-					</div>
-				);
+					);
 			}
 		}
 

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -33,6 +33,7 @@ enum InputTypes {
 	number = "number",
 	checkbox = "checkbox",
 	email = "email",
+	url = "url",
 }
 
 const formatDate = (dateString: string | null): string => {
@@ -203,7 +204,7 @@ const PageUpdate: FC = () => {
 				label: "Yhteenveto",
 				type: InputTypes.textarea,
 				name: "summary",
-				value: nursingHome.summary ? nursingHome.summary : "",
+				value: nursingHome.summary,
 			},
 			{
 				label: textOwner,
@@ -215,7 +216,7 @@ const PageUpdate: FC = () => {
 				label: textAra,
 				type: InputTypes.checkbox,
 				name: "ara",
-				value: nursingHome.ara === "Kyllä",
+				value: nursingHome.ara,
 			},
 			{
 				label: textYearofConst,
@@ -320,17 +321,13 @@ const PageUpdate: FC = () => {
 				label: "Saapuminen julkisilla kulkuyhteyksillä",
 				type: InputTypes.textarea,
 				name: "arrival_guide_public_transit",
-				value: nursingHome.arrival_guide_public_transit
-					? nursingHome.arrival_guide_public_transit
-					: "",
+				value: nursingHome.arrival_guide_public_transit,
 			},
 			{
 				label: "Saapuminen autolla",
 				type: InputTypes.textarea,
 				name: "arrival_guide_car",
-				value: nursingHome.arrival_guide_car
-					? nursingHome.arrival_guide_car
-					: "",
+				value: nursingHome.arrival_guide_car,
 			},
 		];
 
@@ -345,11 +342,11 @@ const PageUpdate: FC = () => {
 				label: textFoodMoreInfo,
 				type: InputTypes.textarea,
 				name: "meals_info",
-				value: nursingHome.meals_info ? nursingHome.meals_info : "",
+				value: nursingHome.meals_info,
 			},
 			{
 				label: textLinkMenu,
-				type: InputTypes.text,
+				type: InputTypes.url,
 				name: "menu_link",
 				value: nursingHome.menu_link,
 			},
@@ -360,13 +357,11 @@ const PageUpdate: FC = () => {
 				label: textActivies,
 				type: InputTypes.textarea,
 				name: "activities_info",
-				value: nursingHome.activities_info
-					? nursingHome.activities_info
-					: "",
+				value: nursingHome.activities_info,
 			},
 			{
 				label: textLinkMoreInfoActivies,
-				type: InputTypes.text,
+				type: InputTypes.url,
 				name: "activities_link",
 				value: nursingHome.activities_link,
 			},
@@ -378,7 +373,7 @@ const PageUpdate: FC = () => {
 			},
 			{
 				label: textLinkMoreInfoOutdoor,
-				type: InputTypes.text,
+				type: InputTypes.url,
 				name: "outdoors_possibilities_link",
 				value: nursingHome.outdoors_possibilities_link,
 			},
@@ -389,7 +384,7 @@ const PageUpdate: FC = () => {
 				label: textVisitingInfo,
 				type: InputTypes.textarea,
 				name: "tour_info",
-				value: nursingHome.tour_info ? nursingHome.tour_info : "",
+				value: nursingHome.tour_info,
 			},
 			{
 				label: "Yhteyshenkilön nimi",
@@ -417,7 +412,7 @@ const PageUpdate: FC = () => {
 			},
 			{
 				label: "Lisätietoja yhteyshenkilön puhelinnumerosta",
-				type: InputTypes.text,
+				type: InputTypes.textarea,
 				name: "contact_phone_info",
 				value: nursingHome.contact_phone_info,
 			},
@@ -428,9 +423,7 @@ const PageUpdate: FC = () => {
 				label: textAccessibility,
 				type: InputTypes.textarea,
 				name: "accessibility_info",
-				value: nursingHome.accessibility_info
-					? nursingHome.accessibility_info
-					: "",
+				value: nursingHome.accessibility_info,
 			},
 		];
 
@@ -439,11 +432,11 @@ const PageUpdate: FC = () => {
 				label: textPersonnel,
 				type: InputTypes.textarea,
 				name: "staff_info",
-				value: nursingHome.staff_info ? nursingHome.staff_info : "",
+				value: nursingHome.staff_info,
 			},
 			{
 				label: textLinkMoreInfoPersonnel,
-				type: InputTypes.text,
+				type: InputTypes.url,
 				name: "staff_satisfaction_info",
 				value: nursingHome.staff_satisfaction_info,
 			},
@@ -454,9 +447,7 @@ const PageUpdate: FC = () => {
 				label: textOtherServices,
 				type: InputTypes.textarea,
 				name: "other_services",
-				value: nursingHome.other_services
-					? nursingHome.other_services
-					: "",
+				value: nursingHome.other_services,
 			},
 		];
 
@@ -465,9 +456,7 @@ const PageUpdate: FC = () => {
 				label: textNearbyServices,
 				type: InputTypes.textarea,
 				name: "nearby_services",
-				value: nursingHome.nearby_services
-					? nursingHome.nearby_services
-					: "",
+				value: nursingHome.nearby_services,
 			},
 		];
 	}
@@ -504,6 +493,16 @@ const PageUpdate: FC = () => {
 		window.location.href = window.location.pathname + "/peruuta";
 	};
 
+	const handleInputChange = (key: string, value: string | boolean) => {
+		if (nursingHome) {
+			const updateNursingHome = { ...nursingHome };
+
+			(updateNursingHome as any)[key] = value;
+
+			setNursingHome(updateNursingHome);
+		}
+	};
+
 	const getInputElement = (field: InputField, index: number): JSX.Element => {
 		if (field.type === "textarea") {
 			return (
@@ -513,10 +512,12 @@ const PageUpdate: FC = () => {
 				>
 					<label htmlFor={field.name}>{field.label}</label>
 					<textarea
-						value={(field.value as string) || ""}
+						defaultValue={(field.value as string) || ""}
 						name={field.name}
 						id={field.name}
-						onChange={() => {}}
+						onChange={event =>
+							handleInputChange(field.name, event.target.value)
+						}
 					></textarea>
 				</div>
 			);
@@ -529,9 +530,11 @@ const PageUpdate: FC = () => {
 					<Checkbox
 						name={field.name}
 						id={field.name}
-						onChange={() => {}}
+						onChange={checked =>
+							handleInputChange(field.name, checked)
+						}
 						children={field.label}
-						isChecked={field.value as boolean}
+						isChecked={(field.value as boolean) || false}
 					/>
 				</div>
 			);
@@ -543,11 +546,13 @@ const PageUpdate: FC = () => {
 				>
 					<label htmlFor={field.name}>{field.label}</label>
 					<input
-						value={(field.value as string) || ""}
+						defaultValue={(field.value as string) || ""}
 						name={field.name}
 						id={field.name}
 						type={field.type}
-						onChange={() => {}}
+						onChange={event =>
+							handleInputChange(field.name, event.target.value)
+						}
 					/>
 				</div>
 			);

--- a/frontend/src/components/PageUpdate.tsx
+++ b/frontend/src/components/PageUpdate.tsx
@@ -543,19 +543,20 @@ const PageUpdate: FC = () => {
 			await requestVacancyStatusUpdate(id, key, formState, imageState);
 
 			if (nursingHome) {
-				const temporaryData: any = { ...nursingHome };
+				const transformNursingHomeData: any = {
+					...nursingHome,
+				};
 
-				delete temporaryData.id;
-				delete temporaryData.pic_digests;
-				delete temporaryData.pics;
-				delete temporaryData.pic_captions;
-				delete temporaryData.report_status;
-				delete temporaryData.rating;
-				delete temporaryData.geolocation;
-				delete temporaryData.has_vacancy;
-				delete temporaryData.basic_update_key;
+				delete transformNursingHomeData.id;
+				delete transformNursingHomeData.pic_digests;
+				delete transformNursingHomeData.pics;
+				delete transformNursingHomeData.pic_captions;
+				delete transformNursingHomeData.report_status;
+				delete transformNursingHomeData.rating;
+				delete transformNursingHomeData.geolocation;
+				delete transformNursingHomeData.has_vacancy;
 
-				const nursingHomeUpdateData: NursingHomeUpdateData = temporaryData;
+				const nursingHomeUpdateData: NursingHomeUpdateData = transformNursingHomeData;
 
 				await requestNursingHomeUpdate(id, key, nursingHomeUpdateData);
 			}

--- a/frontend/src/components/PageUpdateImages.tsx
+++ b/frontend/src/components/PageUpdateImages.tsx
@@ -1,0 +1,211 @@
+import React, { FC, useEffect, useState } from "react";
+import { useParams, useHistory } from "react-router-dom";
+import { useT } from "../i18n";
+import axios from "axios";
+import config from "./config";
+import ImageUpload from "./ImageUpload";
+import { NursingHome, NursingHomeImageName } from "./types";
+import { GetNursingHomeResponse } from "./PageNursingHome";
+
+interface NursingHomeRouteParams {
+	id: string;
+	key: string;
+}
+
+const requestImagesUpdate = async (
+	id: string,
+	key: string,
+	images: object[],
+): Promise<void> => {
+	for (const image of images) {
+		await axios.post(
+			`${config.API_URL}/nursing-homes/${id}/update-image/${key}`,
+			{
+				image: image,
+			},
+		);
+	}
+};
+
+const PageUpdateImages: FC = () => {
+	const { id, key } = useParams<NursingHomeRouteParams>();
+	const history = useHistory();
+	const [nursingHome, setNursingHome] = useState<NursingHome | null>(null);
+	const [popupState, setPopupState] = useState<null | "saving" | "saved">(
+		null,
+	);
+
+	if (!id || !key) throw new Error("Invalid URL!");
+
+	useEffect(() => {
+		axios
+			.get(`${config.API_URL}/nursing-homes/${id}`)
+			.then((response: GetNursingHomeResponse) => {
+				setNursingHome(response.data);
+			})
+			.catch(e => {
+				console.error(e);
+				throw e;
+			});
+	}, [id]);
+
+	const organizationLogo = useT("organizationLogo");
+	const organizationPhotos = useT("organizationPhotos");
+	const organizationPhotosGuide = useT("organizationPhotosGuide");
+	const btnSave = useT("btnSave");
+	const cancel = useT("cancel");
+	const updatePopupSaved = useT("saved");
+	const updatePopupSaving = useT("saving");
+	const loadingText = useT("loadingText");
+
+	const imageState = [
+		{ name: "overview_outside", remove: false, value: "", text: "" },
+		{ name: "apartment", remove: false, value: "", text: "" },
+		{ name: "lounge", remove: false, value: "", text: "" },
+		{ name: "dining_room", remove: false, value: "", text: "" },
+		{ name: "outside", remove: false, value: "", text: "" },
+		{ name: "entrance", remove: false, value: "", text: "" },
+		{ name: "bathroom", remove: false, value: "", text: "" },
+		{ name: "apartment_layout", remove: false, value: "", text: "" },
+		{ name: "nursinghome_layout", remove: false, value: "", text: "" },
+		{ name: "owner_logo", remove: false, value: "", text: "" },
+	];
+
+	const nursinghomeImageTypes = [
+		"overview_outside",
+		"apartment",
+		"lounge",
+		"dining_room",
+		"outside",
+		"entrance",
+		"bathroom",
+		"apartment_layout",
+		"nursinghome_layout",
+	];
+
+	const removeImage = (id: string): void => {
+		const index = imageState.findIndex(x => x.name === id);
+		imageState[index].remove = true;
+		imageState[index].value = "";
+	};
+
+	const updateImageState = (id: string, state: string): void => {
+		const index = imageState.findIndex(x => x.name === id);
+		imageState[index].value = state;
+		imageState[index].remove = false;
+	};
+
+	const updateCaptionState = (id: string, state: string): void => {
+		const index = imageState.findIndex(x => x.name === id);
+		imageState[index].text = state;
+	};
+
+	const cancelEdit = (e: React.FormEvent<HTMLButtonElement>): void => {
+		e.preventDefault();
+
+		history.goBack();
+	};
+
+	const handleSubmit = async (
+		event: React.FormEvent<HTMLFormElement>,
+	): Promise<void> => {
+		try {
+			event.preventDefault();
+
+			setPopupState("saving");
+
+			await requestImagesUpdate(id, key, imageState);
+
+			setPopupState("saved");
+		} catch (error) {
+			console.error(error);
+		}
+	};
+
+	return (
+		<div className="page-update">
+			<div className="page-update-content">
+				{!nursingHome ? (
+					<h1 className="page-update-title">{loadingText}</h1>
+				) : (
+					<form onSubmit={handleSubmit}>
+						<div className="nav-save">
+							<button
+								className="page-update-cancel"
+								onClick={cancelEdit}
+							>
+								{cancel}
+							</button>
+							<button type="submit" className="btn">
+								{btnSave}
+							</button>
+
+							{popupState && (
+								<span className="page-update-popup">
+									{popupState === "saving"
+										? updatePopupSaving
+										: updatePopupSaved}
+								</span>
+							)}
+						</div>
+						<div className="page-update-section nursinghome-logo-upload">
+							<h1 className="page-update-minor-title">
+								{organizationLogo}
+							</h1>
+							<ImageUpload
+								nursingHome={nursingHome}
+								imageName={"owner_logo" as NursingHomeImageName}
+								useButton={true}
+								textAreaClass="textarea-hidden"
+								onRemove={() => {
+									removeImage("owner_logo");
+								}}
+								onChange={file => {
+									updateImageState("owner_logo", file);
+								}}
+							/>
+						</div>
+						<div className="page-update-section">
+							<h2 className="page-update-minor-title">
+								{organizationPhotos}
+							</h2>
+							<p>{organizationPhotosGuide}</p>
+							<div className="flex-container">
+								{nursinghomeImageTypes.map(
+									(imageType, index) => (
+										<ImageUpload
+											key={`${imageType}_${index}`}
+											nursingHome={nursingHome}
+											imageName={
+												imageType as NursingHomeImageName
+											}
+											useButton={false}
+											textAreaClass="nursinghome-upload-caption"
+											onRemove={() => {
+												removeImage(imageType);
+											}}
+											onChange={file => {
+												updateImageState(
+													imageType,
+													file,
+												);
+											}}
+											onCaptionChange={text => {
+												updateCaptionState(
+													imageType,
+													text,
+												);
+											}}
+										/>
+									),
+								)}
+							</div>
+						</div>
+					</form>
+				)}
+			</div>
+		</div>
+	);
+};
+
+export default PageUpdateImages;

--- a/frontend/src/components/PageUpdateImages.tsx
+++ b/frontend/src/components/PageUpdateImages.tsx
@@ -129,25 +129,6 @@ const PageUpdateImages: FC = () => {
 					<h1 className="page-update-title">{loadingText}</h1>
 				) : (
 					<form onSubmit={handleSubmit}>
-						<div className="nav-save">
-							<button
-								className="page-update-cancel"
-								onClick={cancelEdit}
-							>
-								{cancel}
-							</button>
-							<button type="submit" className="btn">
-								{btnSave}
-							</button>
-
-							{popupState && (
-								<span className="page-update-popup">
-									{popupState === "saving"
-										? updatePopupSaving
-										: updatePopupSaved}
-								</span>
-							)}
-						</div>
 						<div className="page-update-section nursinghome-logo-upload">
 							<h1 className="page-update-minor-title">
 								{organizationLogo}
@@ -200,6 +181,25 @@ const PageUpdateImages: FC = () => {
 									),
 								)}
 							</div>
+						</div>
+						<div className="nav-save">
+							<button
+								className="page-update-cancel"
+								onClick={cancelEdit}
+							>
+								{cancel}
+							</button>
+							<button type="submit" className="btn">
+								{btnSave}
+							</button>
+
+							{popupState && (
+								<span className="page-update-popup">
+									{popupState === "saving"
+										? updatePopupSaving
+										: updatePopupSaved}
+								</span>
+							)}
 						</div>
 					</form>
 				)}

--- a/frontend/src/components/Radio.tsx
+++ b/frontend/src/components/Radio.tsx
@@ -6,6 +6,7 @@ interface Props {
 	id: string;
 	isSelected: boolean;
 	onChange: (checked: boolean) => void;
+	onBlur?: () => void;
 	tag?: string;
 	value?: string | boolean;
 }
@@ -14,6 +15,7 @@ const Radio: React.FunctionComponent<Props> = ({
 	name,
 	id,
 	onChange,
+	onBlur,
 	children,
 	isSelected,
 	tag,
@@ -31,6 +33,7 @@ const Radio: React.FunctionComponent<Props> = ({
 				id={id}
 				className="radio-button"
 				value={value as string}
+				onBlur={onBlur}
 			/>
 			<label
 				htmlFor={id}

--- a/frontend/src/components/Radio.tsx
+++ b/frontend/src/components/Radio.tsx
@@ -7,6 +7,7 @@ interface Props {
 	isSelected: boolean;
 	onChange: (checked: boolean) => void;
 	tag?: string;
+	value?: string;
 }
 
 const Radio: React.FunctionComponent<Props> = ({
@@ -15,7 +16,8 @@ const Radio: React.FunctionComponent<Props> = ({
 	onChange,
 	children,
 	isSelected,
-	tag
+	tag,
+	value,
 }) => {
 	return (
 		<div className="radio-container">
@@ -28,15 +30,19 @@ const Radio: React.FunctionComponent<Props> = ({
 				type="radio"
 				id={id}
 				className="radio-button"
+				value={value}
 			/>
-			<label htmlFor={id} className={`radio-label ${tag ? " radio-label-taged" : ""}`}>
+			<label
+				htmlFor={id}
+				className={`radio-label ${tag ? " radio-label-taged" : ""}`}
+			>
 				<span
 					className={`radio-box ${
 						isSelected ? "radio-box-selected" : ""
-					}${
-						tag ? " radio-box-taged" : ""
-					}`}
-				>{tag}</span>
+					}${tag ? " radio-box-taged" : ""}`}
+				>
+					{tag}
+				</span>
 				<span className="radio-label-children">{children}</span>
 			</label>
 		</div>

--- a/frontend/src/components/Radio.tsx
+++ b/frontend/src/components/Radio.tsx
@@ -7,7 +7,7 @@ interface Props {
 	isSelected: boolean;
 	onChange: (checked: boolean) => void;
 	tag?: string;
-	value?: string;
+	value?: string | boolean;
 }
 
 const Radio: React.FunctionComponent<Props> = ({
@@ -30,7 +30,7 @@ const Radio: React.FunctionComponent<Props> = ({
 				type="radio"
 				id={id}
 				className="radio-button"
-				value={value}
+				value={value as string}
 			/>
 			<label
 				htmlFor={id}

--- a/frontend/src/components/types.d.ts
+++ b/frontend/src/components/types.d.ts
@@ -92,6 +92,3 @@ export interface NursingHome {
 		answers: number | null;
 	};
 }
-
-export type OptionalProps<T, K extends keyof T> = Pick<Partial<T>, K> &
-	Omit<T, K>;

--- a/frontend/src/components/types.d.ts
+++ b/frontend/src/components/types.d.ts
@@ -85,11 +85,13 @@ export interface NursingHome {
 	report_status: {
 		status: string;
 		date: string;
-	}
+	};
 	has_vacancy: boolean | null;
 	rating: {
 		average: number | null;
 		answers: number | null;
-	}
-	
+	};
 }
+
+export type OptionalProps<T, K extends keyof T> = Pick<Partial<T>, K> &
+	Omit<T, K>;

--- a/frontend/src/styles/ImageUpload.scss
+++ b/frontend/src/styles/ImageUpload.scss
@@ -1,0 +1,171 @@
+@import "variables.scss";
+
+.nursinghome-upload-container {
+	margin: 10px 0px 45px 0;
+	height: 285px;
+}
+
+.nursinghome-upload-container:nth-of-type(odd) {
+	margin: 10px 40px 45px 0;
+}
+
+.flex-container {
+	display: flex;
+	flex-wrap: wrap;
+	width: 100%;
+}
+
+.nursinghome-upload-img {
+	width: 320px;
+	height: 200px;
+	padding: 5px;
+	border: 2px dashed $border-color;
+}
+
+.nursinghome-upload-img-hover {
+	position: relative;
+	top: -6px;
+	left: -6px;
+	width: 320px;
+	height: 200px;
+	opacity: 0;
+	background-color: rgba(0, 0, 0, 0.75);
+}
+
+.nursinghome-upload-img-inner {
+	width: 100%;
+	height: 100%;
+	background-position: center;
+	background-size: contain;
+	background-repeat: no-repeat;
+
+	&:hover {
+		.nursinghome-upload-img-hover {
+			opacity: 0.9;
+		}
+	}
+}
+
+.nursinghome-upload-placeholder > .nursinghome-upload-img-inner {
+	background: #fff url("/icons/icon-file-upload.svg") 50% 35%/15% no-repeat;
+
+	.input-hidden {
+		position: relative;
+		opacity: 1;
+		top: -20px;
+		left: 0px;
+		width: 100%;
+		height: 100%;
+		opacity: 0;
+		cursor: pointer;
+	}
+}
+
+.nursinghome-upload-img-inner-text {
+	position: relative;
+	top: 130px;
+}
+
+.nursinghome-upload-img-change-text,
+.nursinghome-upload-img-remove-text {
+	position: relative;
+	top: 65px;
+}
+
+.nursinghome-upload-img {
+	text-align: center;
+
+	.btn {
+		margin: 30px 0 0 0;
+		width: 250px;
+	}
+
+	.nursinghome-upload-hidden-remove {
+		position: relative;
+		opacity: 1;
+		top: -50px;
+		left: 170px;
+		width: 100px;
+		height: 100px;
+		border: 1px solid rgba(0, 0, 0, 0);
+		background: rgba(0, 0, 0, 0) url("/icons/icon-trashcan.svg") 50% 30%/35%
+			no-repeat;
+		color: #fff;
+		font-size: 10px;
+		cursor: pointer;
+
+		&:hover {
+			border-color: $border-color;
+		}
+	}
+
+	.nursinghome-upload-button-remove {
+		position: relative;
+		opacity: 1;
+		top: 5px;
+		left: 115px;
+		width: 100px;
+		height: 100px;
+		border: 1px solid rgba(0, 0, 0, 0);
+		background: rgba(0, 0, 0, 0) url("/icons/icon-trashcan.svg") 50% 30%/35%
+			no-repeat;
+		color: #fff;
+		font-size: 10px;
+		cursor: pointer;
+
+		&:hover {
+			border-color: $border-color;
+		}
+	}
+
+	.input-hidden {
+		position: relative;
+		opacity: 1;
+		top: 50px;
+		left: 50px;
+		width: 100px;
+		height: 100px;
+		border: 1px solid rgba(0, 0, 0, 0);
+		background: rgba(0, 0, 0, 0) url("/icons/icon-edit-pen.svg") 50% 30%/35%
+			no-repeat;
+		color: #fff;
+		font-size: 10px;
+
+		&:hover {
+			border-color: $border-color;
+		}
+
+		input {
+			opacity: 0;
+			width: 100%;
+			height: 100%;
+			cursor: pointer;
+		}
+	}
+
+	.input-button {
+		position: relative;
+		opacity: 0;
+		top: 200px;
+		width: 250px;
+		height: 42px;
+		cursor: pointer;
+
+		input {
+			position: relative;
+			left: 40px;
+			opacity: 0;
+			width: 100%;
+			height: 100%;
+			cursor: pointer;
+		}
+	}
+}
+
+.nursinghome-upload-caption {
+	width: 313px;
+	height: 90px;
+	margin: 10px 0 10px 0;
+	font-size: 14px;
+	border: 1px solid $border-color;
+}

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -130,4 +130,10 @@
 		border-bottom: solid 1px $border-color;
 		width: auto;
 	}
+
+	.checkbox-container {
+		label {
+			display: flex;
+		}
+	}
 }

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -14,8 +14,13 @@
 
 .page-update-section {
 	max-width: 680px;
-	padding: 50px 0 50px 0;
 	border-bottom: 1px solid $border-color;
+	padding: 2rem 0 3rem 0;
+	margin-bottom: 1rem;
+
+	&:last-of-type {
+		margin-bottom: 0;
+	}
 }
 
 .nursinghome-logo-upload {
@@ -35,6 +40,11 @@
 
 .page-update-title {
 	margin-top: 1em;
+}
+
+.page-update-info {
+	margin: 2rem 0 0 0;
+	font-size: 0.8rem;
 }
 
 .page-update-status {

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -126,13 +126,15 @@
 	input[type="text"],
 	input[type="number"],
 	input[type="email"],
-	input[type="url"] {
+	input[type="url"],
+	input[type="tel"] {
 		border: none;
 		border-bottom: solid 1px $border-color;
 		width: auto;
 	}
 
-	.checkbox-container {
+	.checkbox-container,
+	.radio-container {
 		label {
 			display: flex;
 		}

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -77,6 +77,13 @@
 	border-radius: $border-radius;
 }
 
+.page-update-submit {
+	&:disabled {
+		cursor: default;
+		opacity: 0.5;
+	}
+}
+
 .page-update-popup {
 	position: fixed;
 	margin-top: 12px;
@@ -99,6 +106,11 @@
 	* {
 		margin-right: 8px;
 	}
+}
+
+.update-images-button {
+	display: inline-flex;
+	align-items: center;
 }
 
 .field {

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -1,6 +1,7 @@
 @import "variables.scss";
 
 .page-update {
+	position: relative;
 	padding: 80px 20px 20px 20px;
 }
 
@@ -36,13 +37,10 @@
 	margin-top: 1em;
 }
 
-.page-update-minor-title {
-	margin-bottom: 40px;
-}
-
-.page-update-data {
-	margin-bottom: 0.5em;
-	padding: 0 0 0 30px;
+.page-update-status {
+	width: 100%;
+	text-align: right;
+	margin: 1rem auto 0 auto;
 }
 
 .page-update-controls {
@@ -100,10 +98,10 @@
 		flex-wrap: wrap;
 
 		.field {
-			flex: 1 1 31%;
+			flex: 1 1 47%;
 			margin-right: 3%;
 
-			&:nth-child(3n),
+			&:nth-child(2n),
 			&:last-child {
 				margin-right: 0;
 			}
@@ -126,6 +124,7 @@
 .update-images-button {
 	display: inline-flex;
 	align-items: center;
+	min-width: 18.75rem;
 }
 
 .field {
@@ -141,6 +140,10 @@
 		font-size: 1rem;
 		font-weight: 600;
 		line-height: 1.5;
+
+		.asterisk {
+			font-size: 0.9em;
+		}
 	}
 
 	.input {
@@ -165,6 +168,15 @@
 			border-color: $link-color;
 			border-bottom-width: 2px;
 			outline: none;
+		}
+
+		&-description {
+			display: inline-block;
+			line-height: 1.5;
+			font-style: italic;
+			font-size: 0.85rem;
+			color: $headline-color;
+			margin: 0.6rem 0;
 		}
 	}
 

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -12,7 +12,7 @@
 }
 
 .page-update-section {
-	width: 680px;
+	max-width: 680px;
 	padding: 50px 0 50px 0;
 	border-bottom: 1px solid $border-color;
 }

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -46,8 +46,6 @@
 }
 
 .page-update-controls {
-	// max-width: 100%;
-	// width: 360px;
 	margin: 0;
 	padding: 0 0 0 0;
 

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -43,7 +43,7 @@
 }
 
 .page-update-info {
-	margin: 2rem 0 0 0;
+	margin: 1.5rem 0 0.5rem 0;
 	font-size: 0.8rem;
 }
 

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -106,10 +106,14 @@
 	}
 }
 
-.page-update-input {
+.field {
 	width: 100%;
 	box-sizing: border-box;
-	margin-bottom: 1rem;
+	padding-bottom: 1.5rem;
+
+	&:not(:last-child) {
+		margin-bottom: 0.75rem;
+	}
 
 	label {
 		display: block;
@@ -151,9 +155,16 @@
 		padding-right: calc(0.625em - 1px);
 		padding-top: calc(0.5em - 1px);
 		font-size: 1rem;
+		font-family: inherit;
 
 		&.error {
-			border: 1px solid $error-color;
+			border-color: $error-color;
+		}
+
+		&:focus {
+			border-color: $link-color;
+			border-bottom-width: 2px;
+			outline: none;
 		}
 	}
 
@@ -169,13 +180,14 @@
 	.radio-container {
 		label {
 			display: flex;
+			font-weight: 400;
 		}
 	}
 
 	&-error {
 		display: block;
 		color: $error-color;
-		margin-top: 10px;
+		margin-top: 0.75rem;
 	}
 
 	legend {

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -88,6 +88,10 @@
 	margin-left: 20px;
 	color: $primary-blue;
 	font-weight: bold;
+
+	&.error {
+		color: $error-color;
+	}
 }
 
 .nav-save {
@@ -103,24 +107,25 @@
 }
 
 .page-update-input {
-	margin-bottom: 1em;
+	width: 100%;
+	box-sizing: border-box;
+	margin-bottom: 1rem;
 
 	label {
 		display: block;
-		margin-bottom: 0.5em;
-		font-weight: bold;
-	}
-
-	textarea,
-	input {
-		box-sizing: border-box;
-		line-height: 2;
+		font-size: 1rem;
+		font-weight: 600;
 	}
 
 	textarea {
-		box-sizing: border-box;
+		border: none;
+		border-bottom: solid 1px $border-color;
 		width: 100%;
-		border: 1px solid $border-color;
+		resize: none;
+		box-sizing: border-box;
+		max-width: 100%;
+		width: 100%;
+		padding-bottom: calc(0.5em - 1px);
 	}
 
 	input[type="text"],
@@ -130,7 +135,34 @@
 	input[type="tel"] {
 		border: none;
 		border-bottom: solid 1px $border-color;
-		width: auto;
+		max-width: 100%;
+		width: 100%;
+		padding-bottom: calc(0.5em - 1px);
+		height: 2.5em;
+	}
+
+	textarea,
+	input {
+		box-sizing: border-box;
+		min-height: 2.5em;
+		border-radius: 0;
+		line-height: 1.5;
+		padding-left: calc(0.625em - 1px);
+		padding-right: calc(0.625em - 1px);
+		padding-top: calc(0.5em - 1px);
+		font-size: 1rem;
+
+		&.error {
+			border: 1px solid $error-color;
+		}
+	}
+
+	.control {
+		box-sizing: border-box;
+		clear: both;
+		font-size: 1rem;
+		position: relative;
+		text-align: left;
 	}
 
 	.checkbox-container,
@@ -138,5 +170,16 @@
 		label {
 			display: flex;
 		}
+	}
+
+	&-error {
+		display: block;
+		color: $error-color;
+		margin-top: 10px;
+	}
+
+	legend {
+		@extend label;
+		margin-bottom: 1em;
 	}
 }

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -96,6 +96,23 @@
 	}
 }
 
+.page-update-columns {
+	@media (min-width: 800px) {
+		display: flex;
+		flex-wrap: wrap;
+
+		.field {
+			flex: 1 1 31%;
+			margin-right: 3%;
+
+			&:nth-child(3n),
+			&:last-child {
+				margin-right: 0;
+			}
+		}
+	}
+}
+
 .nav-save {
 	position: fixed;
 	top: 18px;

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -45,14 +45,9 @@
 	padding: 0 0 0 30px;
 }
 
-.page-update-intro {
-	margin: 1.5em 0 3em 0;
-	padding: 0 0 0 30px;
-}
-
 .page-update-controls {
-	max-width: 100%;
-	width: 360px;
+	// max-width: 100%;
+	// width: 360px;
 	margin: 0;
 	padding: 0 0 0 0;
 

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -114,41 +114,20 @@
 		margin-bottom: 0.75rem;
 	}
 
-	label {
+	.label {
 		display: block;
 		font-size: 1rem;
 		font-weight: 600;
 		line-height: 1.5;
 	}
 
-	textarea {
-		border: solid 1px $border-color;
-		width: 100%;
-		resize: none;
+	.input {
 		box-sizing: border-box;
-		max-width: 100%;
 		width: 100%;
-		padding-bottom: 0.4rem;
-	}
-
-	input[type="text"],
-	input[type="number"],
-	input[type="email"],
-	input[type="url"],
-	input[type="tel"] {
-		border: none;
-		border-bottom: solid 1px $border-color;
 		max-width: 100%;
-		width: 100%;
 		padding-bottom: 0.4rem;
-		height: 2.5em;
-	}
-
-	textarea,
-	input {
-		box-sizing: border-box;
-		min-height: 2.5em;
 		border-radius: 0;
+		min-height: 2.5em;
 		line-height: 1.5;
 		padding-left: 0.5rem;
 		padding-right: 0.5rem;
@@ -167,6 +146,21 @@
 		}
 	}
 
+	textarea {
+		border: solid 1px $border-color;
+		resize: none;
+	}
+
+	input[type="text"],
+	input[type="number"],
+	input[type="email"],
+	input[type="url"],
+	input[type="tel"] {
+		border: none;
+		border-bottom: solid 1px $border-color;
+		height: 2.5em;
+	}
+
 	.control {
 		box-sizing: border-box;
 		clear: both;
@@ -176,7 +170,7 @@
 
 		.icon {
 			position: absolute;
-			bottom: -25px;
+			bottom: -1.56rem;
 			right: 0;
 			background: url("/icons/icon-exclamation-circle.svg");
 			width: 1.125rem;
@@ -184,19 +178,12 @@
 		}
 	}
 
-	.checkbox-container,
-	.radio-container {
-		label {
-			display: flex;
-			font-weight: 400;
-		}
-	}
-
 	.help {
 		display: block;
-		font-size: 0.75rem;
 		position: absolute;
 		left: 0;
+		right: 1.2rem;
+		font-size: 0.75rem;
 		margin-top: 0.4rem;
 		padding-left: 0.5rem;
 		line-height: 1.125rem;
@@ -205,7 +192,7 @@
 	}
 
 	legend {
-		@extend label;
+		@extend .label;
 		margin-bottom: 1em;
 	}
 }

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -142,7 +142,7 @@
 		line-height: 1.5;
 
 		.asterisk {
-			font-size: 0.9em;
+			font-size: 0.8em;
 		}
 	}
 

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -107,8 +107,7 @@
 }
 
 .field {
-	width: 100%;
-	box-sizing: border-box;
+	position: relative;
 	padding-bottom: 1.5rem;
 
 	&:not(:last-child) {
@@ -119,17 +118,17 @@
 		display: block;
 		font-size: 1rem;
 		font-weight: 600;
+		line-height: 1.5;
 	}
 
 	textarea {
-		border: none;
-		border-bottom: solid 1px $border-color;
+		border: solid 1px $border-color;
 		width: 100%;
 		resize: none;
 		box-sizing: border-box;
 		max-width: 100%;
 		width: 100%;
-		padding-bottom: calc(0.5em - 1px);
+		padding-bottom: 0.4rem;
 	}
 
 	input[type="text"],
@@ -141,7 +140,7 @@
 		border-bottom: solid 1px $border-color;
 		max-width: 100%;
 		width: 100%;
-		padding-bottom: calc(0.5em - 1px);
+		padding-bottom: 0.4rem;
 		height: 2.5em;
 	}
 
@@ -151,9 +150,9 @@
 		min-height: 2.5em;
 		border-radius: 0;
 		line-height: 1.5;
-		padding-left: calc(0.625em - 1px);
-		padding-right: calc(0.625em - 1px);
-		padding-top: calc(0.5em - 1px);
+		padding-left: 0.5rem;
+		padding-right: 0.5rem;
+		padding-top: 0.4rem;
 		font-size: 1rem;
 		font-family: inherit;
 
@@ -174,6 +173,15 @@
 		font-size: 1rem;
 		position: relative;
 		text-align: left;
+
+		.icon {
+			position: absolute;
+			bottom: -25px;
+			right: 0;
+			background: url("/icons/icon-exclamation-circle.svg");
+			width: 1.125rem;
+			height: 1.125rem;
+		}
 	}
 
 	.checkbox-container,
@@ -184,10 +192,16 @@
 		}
 	}
 
-	&-error {
+	.help {
 		display: block;
-		color: $error-color;
-		margin-top: 0.75rem;
+		font-size: 0.75rem;
+		position: absolute;
+		left: 0;
+		margin-top: 0.4rem;
+		padding-left: 0.5rem;
+		line-height: 1.125rem;
+		min-height: 1.125rem;
+		color: $input-border;
 	}
 
 	legend {

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -125,7 +125,8 @@
 
 	input[type="text"],
 	input[type="number"],
-	input[type="email"] {
+	input[type="email"],
+	input[type="url"] {
 		border: none;
 		border-bottom: solid 1px $border-color;
 		width: auto;

--- a/frontend/src/styles/PageUpdate.scss
+++ b/frontend/src/styles/PageUpdate.scss
@@ -18,181 +18,14 @@
 }
 
 .nursinghome-logo-upload {
-
 	.nursinghome-upload-img {
 		width: 320px;
 		margin: auto;
 	}
 }
 
-.nursinghome-upload-container {
-	margin: 10px 0px 45px 0;
-	height: 285px;
-}
-
-.nursinghome-upload-container:nth-of-type(odd) {
-	margin: 10px 40px 45px 0;
-}
-
-.flex-container {
-	display: flex;
-	flex-wrap: wrap;
-	width: 100%;
-}
-
-.nursinghome-upload-img {
-	width: 320px;
-	height: 200px;
-	padding: 5px;
-	border: 2px dashed $border-color;
-}
-
-.nursinghome-upload-img-hover {
-	position: relative;
-	top: -6px;
-	left: -6px;
-	width: 320px;
-	height: 200px;
-	opacity: 0;
-	background-color: rgba(0,0,0,0.75);
-}
-
-.nursinghome-upload-img-inner {
-	width: 100%;
-	height: 100%;
-	background-position: center;
-	background-size: contain;
-	background-repeat: no-repeat;
-
-	&:hover {
-		.nursinghome-upload-img-hover{
-			opacity: .9;
-		}
-	}
-}
-
-.nursinghome-upload-placeholder > .nursinghome-upload-img-inner {
-	background: #fff url("/icons/icon-file-upload.svg") 50% 35%/15% no-repeat;
-
-	.input-hidden{
-		position: relative;
-		opacity: 1;
-		top: -20px;
-		left: 0px;
-		width: 100%;
-		height: 100%;
-		opacity: 0;
-		cursor: pointer;
-	}
-}
-
-.nursinghome-upload-img-inner-text {
-	position: relative;
-	top: 130px;
-}
-
-.nursinghome-upload-img-change-text, .nursinghome-upload-img-remove-text {
-	position: relative;
-	top: 65px;
-}
-
-.nursinghome-upload-img {
-	text-align: center;
-
-	.btn {
-		margin: 30px 0 0 0;
-		width: 250px;
-	}
-
-	.nursinghome-upload-hidden-remove{
-		position: relative;
-		opacity: 1;
-		top: -50px;
-		left: 170px;
-		width: 100px;
-		height: 100px;
-		border: 1px solid rgba(0,0,0,0);
-		background: rgba(0,0,0,0) url("/icons/icon-trashcan.svg") 50% 30%/35% no-repeat;
-		color: #fff;
-		font-size: 10px;
-		cursor: pointer;
-
-		&:hover{
-			border-color: $border-color;
-		}
-	}
-
-	.nursinghome-upload-button-remove{
-		position: relative;
-		opacity: 1;
-		top: 5px;
-		left: 115px;
-		width: 100px;
-		height: 100px;
-		border: 1px solid rgba(0,0,0,0);
-		background: rgba(0,0,0,0) url("/icons/icon-trashcan.svg") 50% 30%/35% no-repeat;
-		color: #fff;
-		font-size: 10px;
-		cursor: pointer;
-
-		&:hover{
-			border-color: $border-color;
-		}
-	}
-	
-	.input-hidden{
-		position: relative;
-		opacity: 1;
-		top: 50px;
-		left: 50px;
-		width: 100px;
-		height: 100px;
-		border: 1px solid rgba(0,0,0,0);
-		background: rgba(0,0,0,0) url("/icons/icon-edit-pen.svg") 50% 30%/35% no-repeat;
-		color: #fff;
-		font-size: 10px;
-
-		&:hover {
-			border-color: $border-color;
-		}
-
-		input {
-			opacity: 0;
-			width: 100%;
-			height: 100%;
-			cursor: pointer;
-		}
-	}
-
-	.input-button{
-		position: relative;
-		opacity: 0;
-		top: 200px;
-		width: 250px;
-		height: 42px;
-		cursor: pointer;
-
-		input {
-			position: relative;
-			left: 40px;
-			opacity: 0;
-			width: 100%;
-			height: 100%;
-			cursor: pointer;
-		}
-	}
-}
-
 .upload-button-hidden {
 	display: none;
-}
-
-.nursinghome-upload-caption {
-	width: 313px;
-	height: 90px;
-	margin: 10px 0 10px 0;
-	font-size: 14px;
-	border: 1px solid $border-color;
 }
 
 .textarea-hidden {
@@ -231,23 +64,22 @@
 
 .page-update-cancel {
 	border-width: 1px;
-    cursor: pointer;
-    justify-content: center;
-    padding-bottom: calc(0.375em - 1px);
-    padding-left: 0.75em;
-    padding-right: 0.75em;
-    padding-top: calc(0.375em - 1px);
-    text-align: center;
-    white-space: nowrap;
-    text-transform: uppercase;
-    font-size: 14px;
-    font-weight: 600;
-    min-width: 7em;
-    height: 3em;
-    color: $headline-color;
+	cursor: pointer;
+	justify-content: center;
+	padding-bottom: calc(0.375em - 1px);
+	padding-left: 0.75em;
+	padding-right: 0.75em;
+	padding-top: calc(0.375em - 1px);
+	text-align: center;
+	white-space: nowrap;
+	text-transform: uppercase;
+	font-size: 14px;
+	font-weight: 600;
+	min-width: 7em;
+	height: 3em;
+	color: $headline-color;
 	border: 1px solid $light-gray;
 	border-radius: $border-radius;
-
 }
 
 .page-update-popup {
@@ -265,7 +97,37 @@
 	right: 250px;
 	z-index: 9999;
 
-	*{
+	* {
 		margin-right: 8px;
+	}
+}
+
+.page-update-input {
+	margin-bottom: 1em;
+
+	label {
+		display: block;
+		margin-bottom: 0.5em;
+		font-weight: bold;
+	}
+
+	textarea,
+	input {
+		box-sizing: border-box;
+		line-height: 2;
+	}
+
+	textarea {
+		box-sizing: border-box;
+		width: 100%;
+		border: 1px solid $border-color;
+	}
+
+	input[type="text"],
+	input[type="number"],
+	input[type="email"] {
+		border: none;
+		border-bottom: solid 1px $border-color;
+		width: auto;
 	}
 }

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -439,18 +439,20 @@ export const translations = {
 		"sv-FI": "Fotografier från vårdhemmet",
 	},
 	organizationPhotosGuide: {
-		"fi-FI": "Laita erilaisia kuvia ulko- ja sisäpuolelta (esimerkiksi sisäänkäynti, piha-alue, oleskelutilat, ruokailutilat, asunto ja kylpyhuone). Ensimmäisessä kuvapaikassa oleva kuva näkyy hoivakotilistauksessa. Kaikki kuvat näkyvät hoivakodin sivulla. Kuvien maksimikoko on 4Mt ja kuvatekstien pituus korkeintaan 200 merkkiä.",
-		"sv-FI": "Lägg ut olika bilder som är tagna utomhus och inomhus (t.ex. ingång, gårdsplan, vistelserum, matsal, bostad och badrum). Om du lägger ut bilder på människor, kom ihåg att be om tillstånd. Bilden på den första bildplatsen syns i listan över vårdhem. Alla bilder syns på vårdhemmets sida. ",
+		"fi-FI":
+			"Laita erilaisia kuvia ulko- ja sisäpuolelta (esimerkiksi sisäänkäynti, piha-alue, oleskelutilat, ruokailutilat, asunto ja kylpyhuone). Ensimmäisessä kuvapaikassa oleva kuva näkyy hoivakotilistauksessa. Kaikki kuvat näkyvät hoivakodin sivulla. Kuvien maksimikoko on 4Mt ja kuvatekstien pituus korkeintaan 200 merkkiä.",
+		"sv-FI":
+			"Lägg ut olika bilder som är tagna utomhus och inomhus (t.ex. ingång, gårdsplan, vistelserum, matsal, bostad och badrum). Om du lägger ut bilder på människor, kom ihåg att be om tillstånd. Bilden på den första bildplatsen syns i listan över vårdhem. Alla bilder syns på vårdhemmets sida. ",
 	},
-	emptyImageSpot:{
+	emptyImageSpot: {
 		"fi-FI": "Tyhjä kuvapaikka",
 		"sv-FI": "Tom bildplats",
 	},
-	swapImage:{
+	swapImage: {
 		"fi-FI": "Vaihda kuva",
 		"sv-FI": "Byt bild",
 	},
-	imageUploadTooltip:{
+	imageUploadTooltip: {
 		"fi-FI": "Valitse kuva",
 		"sv-FI": "Välj bilden",
 	},
@@ -475,8 +477,10 @@ export const translations = {
 		"sv-FI": "Lägg till en bildtext genom att skriva här.",
 	},
 	cancelPageContent: {
-		"fi-FI": "Voit halutessasi palata edelliselle sivulle muokkaamaan tai sulkea tämän sivun.",
-		"sv-FI": "Om du vill kan du gå tillbaka till föregående sida för att redigera eller stänga sidan.",
+		"fi-FI":
+			"Voit halutessasi palata edelliselle sivulle muokkaamaan tai sulkea tämän sivun.",
+		"sv-FI":
+			"Om du vill kan du gå tillbaka till föregående sida för att redigera eller stänga sidan.",
 	},
 	clearFilters: {
 		"fi-FI": "Poista rajaukset",
@@ -718,23 +722,32 @@ export const translations = {
 	},
 	status_no_info: {
 		"fi-FI": "Sijaintikunta valvoo. Valvontakäynnin tietoja ei saatavilla.",
-		"sv-FI": "Kommunen där vårdhemmet är beläget sköter tillsynen. Uppgifter saknas.",
+		"sv-FI":
+			"Kommunen där vårdhemmet är beläget sköter tillsynen. Uppgifter saknas.",
 	},
 	status_ok_long: {
-		"fi-FI": "Erinomainen: Toiminta on lain vaatimusten ja sopimuksen mukaista.",
-		"sv-FI": "Utmärkt: Verksamheten är förenlig med lagens krav och avtalet.",
+		"fi-FI":
+			"Erinomainen: Toiminta on lain vaatimusten ja sopimuksen mukaista.",
+		"sv-FI":
+			"Utmärkt: Verksamheten är förenlig med lagens krav och avtalet.",
 	},
 	status_small_issues_long: {
-		"fi-FI": "Hyvä: Toiminnassa on pientä parannettavaa, joka ei kuitenkaan heikennä asiakkaiden hoivan tai turvallisuuden toteutumista.",
-		"sv-FI": "God: Det finns små brister i verksamheten som bör avhjälpas, men de försvagar dock inte klienternas omsorg eller säkerhet.",
+		"fi-FI":
+			"Hyvä: Toiminnassa on pientä parannettavaa, joka ei kuitenkaan heikennä asiakkaiden hoivan tai turvallisuuden toteutumista.",
+		"sv-FI":
+			"God: Det finns små brister i verksamheten som bör avhjälpas, men de försvagar dock inte klienternas omsorg eller säkerhet.",
 	},
 	status_significant_issues_long: {
-		"fi-FI": "Tyydyttävä: Toiminnassa puutteita, jotka palveluntuottajan tulee korjata annetussa määräajassa laadukkaan hoivan toteuttamiseksi.",
-		"sv-FI": "Nöjaktig: det finns brister i verksamheten som tjänsteproducenten ska avhjälpa inom utsatt tid för att vården ska vara av hög kvalitet.",
+		"fi-FI":
+			"Tyydyttävä: Toiminnassa puutteita, jotka palveluntuottajan tulee korjata annetussa määräajassa laadukkaan hoivan toteuttamiseksi.",
+		"sv-FI":
+			"Nöjaktig: det finns brister i verksamheten som tjänsteproducenten ska avhjälpa inom utsatt tid för att vården ska vara av hög kvalitet.",
 	},
 	status_surveillance_long: {
-		"fi-FI": "Tehostetussa valvonnassa: Palveluntuottajan toiminnassa on ilmennyt useita laatupoikkeamia, joiden korjaamista kaupunki valvoo.",
-		"sv-FI": "Under effektiviserad tillsyn: I tjänsteproducentens verksamhet har det framkommit flera kvalitetsavvikelser. Staden övervakar att dessa avhjälps.",
+		"fi-FI":
+			"Tehostetussa valvonnassa: Palveluntuottajan toiminnassa on ilmennyt useita laatupoikkeamia, joiden korjaamista kaupunki valvoo.",
+		"sv-FI":
+			"Under effektiviserad tillsyn: I tjänsteproducentens verksamhet har det framkommit flera kvalitetsavvikelser. Staden övervakar att dessa avhjälps.",
 	},
 	reportScore: {
 		"fi-FI": "Valvontakäynnin loppuarvio",
@@ -768,15 +781,15 @@ export const translations = {
 		"fi-FI": "Omaisten antamat arviot",
 		"sv-FI": "Anhörigas bedömningar",
 	},
-	nursingHomeReviews:{
+	nursingHomeReviews: {
 		"fi-FI": "Arviot hoivakodista",
 		"sv-FI": "Bedömningar av vårdhemmet",
 	},
-	linkBackToBasicInfo:{
+	linkBackToBasicInfo: {
 		"fi-FI": "Palaa perustietoihin",
 		"sv-FI": "Gå tillbaka till basuppgifterna",
 	},
-	nReviews:{
+	nReviews: {
 		"fi-FI": "arviota",
 		"sv-FI": "bedömningar",
 	},
@@ -789,99 +802,178 @@ export const translations = {
 		"sv-FI": "Hur samlas bedömningar in?",
 	},
 	reviewFooterPart1: {
-		"fi-FI": "Omainen voi tehdä arvioinnin Espoon kaupungin antamalla tunnuksella. Portaaliin ei tallenneta arvioinnin tekijän henkilötietoja. Arvio tehdään valitsemalla tyytyväisyyttä kuvaava numeroarvo.",
-		"sv-FI": "En anhörig kan göra en bedömning med hjälp av en kod som Esbo stad gett. Personuppgifter om den som gör bedömningen lagras inte i portalen. Bedömningen görs genom att man väljer ett siffervärde som beskriver tillfredsställelsen.",
+		"fi-FI":
+			"Omainen voi tehdä arvioinnin Espoon kaupungin antamalla tunnuksella. Portaaliin ei tallenneta arvioinnin tekijän henkilötietoja. Arvio tehdään valitsemalla tyytyväisyyttä kuvaava numeroarvo.",
+		"sv-FI":
+			"En anhörig kan göra en bedömning med hjälp av en kod som Esbo stad gett. Personuppgifter om den som gör bedömningen lagras inte i portalen. Bedömningen görs genom att man väljer ett siffervärde som beskriver tillfredsställelsen.",
 	},
 	reviewFooterPart2: {
-		"fi-FI": "1=erittäin huono, 2=huono, 3=tyydyttävä, 4=hyvä, 5=erinomainen",
+		"fi-FI":
+			"1=erittäin huono, 2=huono, 3=tyydyttävä, 4=hyvä, 5=erinomainen",
 		"sv-FI": "1=mycket dålig, 2=dålig, 3=nöjaktig, 4=god, 5=utmärkt",
 	},
 	reviewFooterPart3: {
-		"fi-FI": "Vapaan palautteen mahdollisuus sekä asiakkaiden antamat arviot on tarkoitus lisätä tähän portaaliin myöhemmin.",
-		"sv-FI": "Det är meningen att en möjlighet till fritt formulerad respons och klienternas bedömningar ska läggas till i denna portal senare.",
+		"fi-FI":
+			"Vapaan palautteen mahdollisuus sekä asiakkaiden antamat arviot on tarkoitus lisätä tähän portaaliin myöhemmin.",
+		"sv-FI":
+			"Det är meningen att en möjlighet till fritt formulerad respons och klienternas bedömningar ska läggas till i denna portal senare.",
 	},
 	reviewFooterPart4: {
-		"fi-FI": "Asiakas ja/tai omainen voi antaa palautetta hoivakodin toiminnasta (esimerkiksi yksittäisistä tilanteista)",
-		"sv-FI": "Klienten och/eller den anhöriga kan ge respons på vårdhemmets verksamhet (till exempel på enskilda situationer)",
+		"fi-FI":
+			"Asiakas ja/tai omainen voi antaa palautetta hoivakodin toiminnasta (esimerkiksi yksittäisistä tilanteista)",
+		"sv-FI":
+			"Klienten och/eller den anhöriga kan ge respons på vårdhemmets verksamhet (till exempel på enskilda situationer)",
 	},
-	reviewFooterLink:{
+	reviewFooterLink: {
 		"fi-FI": "Espoon kaupungin palautepalvelun kautta.",
 		"sv-FI": "via Esbo stads responstjänst",
 	},
-	urlReviewFooterLink:{
-		"fi-FI": "https://easiointi.espoo.fi/eFeedback/fi/Feedback/21-Senioripalvelut",
-		"sv-FI": "https://easiointi.espoo.fi/eFeedback/sv/Feedback/21-Senioripalvelut",
+	urlReviewFooterLink: {
+		"fi-FI":
+			"https://easiointi.espoo.fi/eFeedback/fi/Feedback/21-Senioripalvelut",
+		"sv-FI":
+			"https://easiointi.espoo.fi/eFeedback/sv/Feedback/21-Senioripalvelut",
 	},
-	aboutToGiveReview:{
+	aboutToGiveReview: {
 		"fi-FI": "Olet antamassa arviota hoivakodista",
 		"sv-FI": "Du håller på att göra en bedömning av vårdhemmet",
 	},
-	reviewHelpPart1:{
+	reviewHelpPart1: {
 		"fi-FI": "Antamalla arvion autat hoivakotia kehittämään palvelujaan.",
-		"sv-FI": "Genom att göra en bedömning hjälper du vårdhemmet att utveckla sina tjänster.",
+		"sv-FI":
+			"Genom att göra en bedömning hjälper du vårdhemmet att utveckla sina tjänster.",
 	},
-	reviewHelpPart2:{
+	reviewHelpPart2: {
 		"fi-FI": "Vastaaminen kestää noin 2 minuuttia.",
 		"sv-FI": "Det tar cirka 2 minuter att svara.",
 	},
-	reviewHelpPart3:{
-		"fi-FI": "Kirjoita saamasi tunnus. Tunnus on tarkoitettu vain sinun käyttöösi.",
+	reviewHelpPart3: {
+		"fi-FI":
+			"Kirjoita saamasi tunnus. Tunnus on tarkoitettu vain sinun käyttöösi.",
 		"sv-FI": "Skriv koden du fått. Koden är endast avsedd för ditt bruk.",
 	},
-	code:{
+	code: {
 		"fi-FI": "Tunnus",
 		"sv-FI": "Kod",
 	},
-	wrongCode:{
+	wrongCode: {
 		"fi-FI": "Virheellinen tunnus",
 		"sv-FI": "Felaktig kod",
 	},
-	start:{
+	start: {
 		"fi-FI": "Aloita",
 		"sv-FI": "Börja",
 	},
-	thankYouReview:{
+	thankYouReview: {
 		"fi-FI": "Kiitos arviostasi",
 		"sv-FI": "Tack för din bedömning",
 	},
-	backToFrontpage:{
+	backToFrontpage: {
 		"fi-FI": "Palaa palvelun etusivulle",
 		"sv-FI": "Gå tillbaka till tjänstens första sida",
 	},
-	feedbackRelationReview:{
+	feedbackRelationReview: {
 		"fi-FI": "Omaisten arvio",
 		"sv-FI": "Anhörigas bedömning",
 	},
-	feedbackNoReviews:{
+	feedbackNoReviews: {
 		"fi-FI": "Ei annettuja arvioita",
 		"sv-FI": "Inga bedömningar",
 	},
-	feedbackReviews:{
+	feedbackReviews: {
 		"fi-FI": "arviota",
 		"sv-FI": "bedömningar",
 	},
-	feedbackGreat:{
+	feedbackGreat: {
 		"fi-FI": "Erinomainen",
 		"sv-FI": "Utmärkt",
 	},
-	feedbackGood:{
+	feedbackGood: {
 		"fi-FI": "Hyvä",
 		"sv-FI": "God",
 	},
-	feedbackOk:{
+	feedbackOk: {
 		"fi-FI": "Tyydyttävä",
 		"sv-FI": "Nöjaktig",
 	},
-	feedbackBad:{
+	feedbackBad: {
 		"fi-FI": "Huono",
 		"sv-FI": "Dålig",
 	},
-	feedbackVeryBad:{
+	feedbackVeryBad: {
 		"fi-FI": "Erittäin huono",
 		"sv-FI": "Mycket dålig",
 	},
 	"Suomi|Ruotsi": {
 		"fi-FI": "Suomi|Ruotsi",
 		"sv-FI": "Svenska/Finska",
+	},
+	summary: {
+		"fi-FI": "Yhteenveto",
+		"sv-FI": "Sammandrag",
+	},
+	buildingInfo: {
+		"fi-FI": "Lisätietoja hoivakodista",
+		"sv-FI": "Mera information",
+	},
+	apartmentCountInfo: {
+		"fi-FI": "Lisätietoja asuntojen määrästä",
+		"sv-FI": "Mer information",
+	},
+	apartmentsHaveBathroom: {
+		"fi-FI": "Asunnoissa oma kylpyhuone",
+		"sv-FI": "Eget badrum",
+	},
+	rentInfo: {
+		"fi-FI": "Lisätietoja vuokrasta",
+		"sv-FI": "Mer information",
+	},
+	languageInfo: {
+		"fi-FI": "Lisätietoja palvelukielestä",
+		"sv-FI": "Mer information",
+	},
+	address: {
+		"fi-FI": "Katuosoite",
+		"sv-FI": "Adress",
+	},
+	postalCode: {
+		"fi-FI": "Postinumero",
+		"sv-FI": "Postnummer",
+	},
+	city: {
+		"fi-FI": "Kaupunki",
+		"sv-FI": "Stad",
+	},
+	district: {
+		"fi-FI": "Kaupunginosa",
+		"sv-FI": "Distrikt",
+	},
+	arrivalGuidePublicTransit: {
+		"fi-FI": "Saapuminen julkisilla kulkuyhteyksillä",
+		"sv-FI": "Mer information",
+	},
+	arrivalGuideCar: {
+		"fi-FI": "Saapuminen autolla",
+		"sv-FI": "Mer information",
+	},
+	contactName: {
+		"fi-FI": "Yhteyshenkilön nimi",
+		"sv-FI": "Mer information",
+	},
+	contactTitle: {
+		"fi-FI": "Yhteyshenkilön titteli",
+		"sv-FI": "Mer information",
+	},
+	contactPhone: {
+		"fi-FI": "Yhteyshenkilön puhelinnumero",
+		"sv-FI": "Mer information",
+	},
+	contactEmail: {
+		"fi-FI": "Yhteyshenkilön sähköposti",
+		"sv-FI": "Mer information",
+	},
+	contactPhoneInfo: {
+		"fi-FI": "Lisätietoja yhteyshenkilön puhelinnumerosta",
+		"sv-FI": "Mer information",
 	},
 };

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -976,4 +976,12 @@ export const translations = {
 		"fi-FI": "Lisätietoja yhteyshenkilön puhelinnumerosta",
 		"sv-FI": "Mer information",
 	},
+	fieldIsRequired: {
+		"fi-FI": "Kenttä on pakollinen",
+		"sv-FI": "Mer information",
+	},
+	formIsInvalid: {
+		"fi-FI": "Lomakkeessa on virheitä!",
+		"sv-FI": "Mer information",
+	},
 };

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -908,13 +908,13 @@ export const translations = {
 		"fi-FI": "Suomi|Ruotsi",
 		"sv-FI": "Svenska/Finska",
 	},
-	summary: {
-		"fi-FI": "Yhteenveto",
-		"sv-FI": "Yhteenveto",
+	nursingHomeSummary: {
+		"fi-FI": "Tiivistelmä hoivakodista",
+		"sv-FI": "Tiivistelmä hoivakodista",
 	},
 	buildingInfo: {
-		"fi-FI": "Lisätietoja hoivakodista",
-		"sv-FI": "Lisätietoja hoivakodista",
+		"fi-FI": "Lisätietoja rakennuksesta",
+		"sv-FI": "Lisätietoja rakennuksesta",
 	},
 	apartmentCountInfo: {
 		"fi-FI": "Lisätietoja asuntojen määrästä",
@@ -983,5 +983,9 @@ export const translations = {
 	formIsInvalid: {
 		"fi-FI": "Lomakkeessa on virheitä!",
 		"sv-FI": "Lomakkeessa on virheitä!",
+	},
+	contactDescription: {
+		"fi-FI": "Yhteydenottoihin liittyvä kuvaus",
+		"sv-FI": "Yhteydenottoihin liittyvä kuvaus",
 	},
 };

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -1112,4 +1112,8 @@ export const translations = {
 		"fi-FI": "Lisää kuvia",
 		"sv-FI": "Lisää kuvia",
 	},
+	fieldsWithAsteriskAreMandatory: {
+		"fi-FI": "Tähdellä * merkityt kentät ovat pakollisia",
+		"sv-FI": "Tähdellä * merkityt kentät ovat pakollisia",
+	},
 };

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -948,11 +948,11 @@ export const translations = {
 		"fi-FI": "Kaupunginosa",
 		"sv-FI": "Distrikt",
 	},
-	arrivalGuidePublicTransit: {
+	arrivalPublicTransit: {
 		"fi-FI": "Saapuminen julkisilla kulkuyhteyksillä",
 		"sv-FI": "Saapuminen julkisilla kulkuyhteyksillä",
 	},
-	arrivalGuideCar: {
+	arrivalCar: {
 		"fi-FI": "Saapuminen autolla",
 		"sv-FI": "Saapuminen autolla",
 	},

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -909,8 +909,8 @@ export const translations = {
 		"sv-FI": "Svenska/Finska",
 	},
 	nursingHomeSummary: {
-		"fi-FI": "Tiivistelmä hoivakodista",
-		"sv-FI": "Tiivistelmä hoivakodista",
+		"fi-FI": "Lyhyt kuvaus hoivakodista",
+		"sv-FI": "Lyhyt kuvaus hoivakodista",
 	},
 	buildingInfo: {
 		"fi-FI": "Lisätietoja rakennuksesta",
@@ -921,8 +921,8 @@ export const translations = {
 		"sv-FI": "Lisätietoja asuntojen määrästä",
 	},
 	apartmentsHaveBathroom: {
-		"fi-FI": "Asunnoissa oma kylpyhuone",
-		"sv-FI": "Asunnoissa oma kylpyhuone",
+		"fi-FI": "Kaikissa asunnoissa on oma kylpyhuone",
+		"sv-FI": "Kaikissa asunnoissa on oma kylpyhuone",
 	},
 	rentInfo: {
 		"fi-FI": "Lisätietoja vuokrasta",
@@ -987,5 +987,35 @@ export const translations = {
 	contactDescription: {
 		"fi-FI": "Yhteydenottoihin liittyvä kuvaus",
 		"sv-FI": "Yhteydenottoihin liittyvä kuvaus",
+	},
+	hasLAHapartments: {
+		"fi-FI": "Hoivakodissa on lyhytaikaisen asumisen asuntoja",
+		"sv-FI": "Hoivakodissa on lyhytaikaisen asumisen asuntoja",
+	},
+	updateNursingHomeTitle: {
+		"fi-FI": "Hoivakodin tietojen muokkaaminen",
+		"sv-FI": "Hoivakodin tietojen muokkaaminen",
+	},
+	ownerOrganisation: {
+		"fi-FI": "Organisaatio joka omistaa hoivakodin",
+		"sv-FI": "Organisaatio joka omistaa hoivakodin",
+	},
+	numTotalApartments: {
+		"fi-FI": "Hoivakodin asuntojen kokonaismäärä",
+		"sv-FI": "Hoivakodin asuntojen kokonaismäärä",
+	},
+	tourInfoPlaceholder: {
+		"fi-FI":
+			"Etukäteen sopimalla voit tulla tutustumaan toimintaamme paikan päälle",
+		"sv-FI":
+			"Etukäteen sopimalla voit tulla tutustumaan toimintaamme paikan päälle",
+	},
+	accessibilityInfo: {
+		"fi-FI": "Tietoja esteettömyydestä",
+		"sv-FI": "Tietoja esteettömyydestä",
+	},
+	nursingHomeName: {
+		"fi-FI": "Hoivakodin nimi",
+		"sv-FI": "Hoivakodin nimi",
 	},
 };

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -426,9 +426,9 @@ export const translations = {
 		"fi-FI": "Vapaiden asuntojen tilanne",
 		"sv-FI": "Lediga bostäder",
 	},
-	pageUpdateIntro: {
-		"fi-FI": "Valitse hoivakodin vapaiden asuntojen tilanne:",
-		"sv-FI": "Välj situationen för lediga bostäder på vårdhemmet:",
+	selectVancyStatus: {
+		"fi-FI": "Valitse hoivakodin vapaiden asuntojen tilanne",
+		"sv-FI": "Välj situationen för lediga bostäder på vårdhemmet",
 	},
 	organizationLogo: {
 		"fi-FI": "Organisaation / Hoivakodin omistajan logo",

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -910,27 +910,27 @@ export const translations = {
 	},
 	summary: {
 		"fi-FI": "Yhteenveto",
-		"sv-FI": "Sammandrag",
+		"sv-FI": "Yhteenveto",
 	},
 	buildingInfo: {
 		"fi-FI": "Lisätietoja hoivakodista",
-		"sv-FI": "Mera information",
+		"sv-FI": "Lisätietoja hoivakodista",
 	},
 	apartmentCountInfo: {
 		"fi-FI": "Lisätietoja asuntojen määrästä",
-		"sv-FI": "Mer information",
+		"sv-FI": "Lisätietoja asuntojen määrästä",
 	},
 	apartmentsHaveBathroom: {
 		"fi-FI": "Asunnoissa oma kylpyhuone",
-		"sv-FI": "Eget badrum",
+		"sv-FI": "Asunnoissa oma kylpyhuone",
 	},
 	rentInfo: {
 		"fi-FI": "Lisätietoja vuokrasta",
-		"sv-FI": "Mer information",
+		"sv-FI": "Lisätietoja vuokrasta",
 	},
 	languageInfo: {
 		"fi-FI": "Lisätietoja palvelukielestä",
-		"sv-FI": "Mer information",
+		"sv-FI": "Lisätietoja palvelukielestä",
 	},
 	address: {
 		"fi-FI": "Katuosoite",
@@ -950,38 +950,38 @@ export const translations = {
 	},
 	arrivalGuidePublicTransit: {
 		"fi-FI": "Saapuminen julkisilla kulkuyhteyksillä",
-		"sv-FI": "Mer information",
+		"sv-FI": "Saapuminen julkisilla kulkuyhteyksillä",
 	},
 	arrivalGuideCar: {
 		"fi-FI": "Saapuminen autolla",
-		"sv-FI": "Mer information",
+		"sv-FI": "Saapuminen autolla",
 	},
 	contactName: {
 		"fi-FI": "Yhteyshenkilön nimi",
-		"sv-FI": "Mer information",
+		"sv-FI": "Yhteyshenkilön nimi",
 	},
 	contactTitle: {
 		"fi-FI": "Yhteyshenkilön titteli",
-		"sv-FI": "Mer information",
+		"sv-FI": "Yhteyshenkilön titteli",
 	},
 	contactPhone: {
 		"fi-FI": "Yhteyshenkilön puhelinnumero",
-		"sv-FI": "Mer information",
+		"sv-FI": "Yhteyshenkilön puhelinnumero",
 	},
 	contactEmail: {
 		"fi-FI": "Yhteyshenkilön sähköposti",
-		"sv-FI": "Mer information",
+		"sv-FI": "Yhteyshenkilön sähköposti",
 	},
 	contactPhoneInfo: {
 		"fi-FI": "Lisätietoja yhteyshenkilön puhelinnumerosta",
-		"sv-FI": "Mer information",
+		"sv-FI": "Lisätietoja yhteyshenkilön puhelinnumerosta",
 	},
 	fieldIsRequired: {
 		"fi-FI": "Kenttä on pakollinen",
-		"sv-FI": "Mer information",
+		"sv-FI": "Kenttä on pakollinen",
 	},
 	formIsInvalid: {
 		"fi-FI": "Lomakkeessa on virheitä!",
-		"sv-FI": "Mer information",
+		"sv-FI": "Lomakkeessa on virheitä!",
 	},
 };

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -1018,4 +1018,98 @@ export const translations = {
 		"fi-FI": "Hoivakodin nimi",
 		"sv-FI": "Hoivakodin nimi",
 	},
+	helperSummary: {
+		"fi-FI": "Hoivakodin palvelulupaus.",
+		"sv-FI": "Hoivakodin palvelulupaus.",
+	},
+	partlyARADestination: {
+		"fi-FI": "Osa paikoista ARA-talossa",
+		"sv-FI": "Osa paikoista ARA-talossa",
+	},
+	helperBuildingInfo: {
+		"fi-FI":
+			"Tässä voit kertoa mahdollisista tehdyistä tai tulossa olevista peruskorjauksista, laajennuksista jne.",
+		"sv-FI":
+			"Tässä voit kertoa mahdollisista tehdyistä tai tulossa olevista peruskorjauksista, laajennuksista jne.",
+	},
+	helperApartmentCountInfo: {
+		"fi-FI":
+			"Tässä voit kertoa esim. minkä kokoisiin ryhmäkoteihin hoivakoti jakaantuu ja kuinka monta asuntoa on per kerros.",
+		"sv-FI":
+			"Tässä voit kertoa esim. minkä kokoisiin ryhmäkoteihin hoivakoti jakaantuu ja kuinka monta asuntoa on per kerros.",
+	},
+	helperApartmentSize: {
+		"fi-FI": "Esim. 18-25.",
+		"sv-FI": "Esim. 18-25.",
+	},
+	helperRent: {
+		"fi-FI": "Esim. 700-800.",
+		"sv-FI": "Esim. 700-800.",
+	},
+	helperRentInfo: {
+		"fi-FI": "Mitä yhteisiä tiloja asiakkaan vuokraan sisältyy.",
+		"sv-FI": "Mitä yhteisiä tiloja asiakkaan vuokraan sisältyy.",
+	},
+	helperLanguage: {
+		"fi-FI": "Esim. lisätietoa henkilökunnan muusta kielitaidosta.",
+		"sv-FI": "Esim. lisätietoa henkilökunnan muusta kielitaidosta.",
+	},
+	foodOwnKitchen: {
+		"fi-FI": "Oma valmistuskeittiö",
+		"sv-FI": "Oma valmistuskeittiö",
+	},
+	foodDelivered: {
+		"fi-FI": "Ruoka toimitetaan muualta (valmiina tai puolivalmiina)",
+		"sv-FI": "Ruoka toimitetaan muualta (valmiina tai puolivalmiina)",
+	},
+	activitiesInfo: {
+		"fi-FI": "Kuvaus hoivakodissa järjestettävästä toiminnasta",
+		"sv-FI": "Kuvaus hoivakodissa järjestettävästä toiminnasta",
+	},
+	helperActivitiesLink: {
+		"fi-FI":
+			"Jos hoivakodin sivuilla on esim. ulkoilukalenteri, laita sen linkki tähän.",
+		"sv-FI":
+			"Jos hoivakodin sivuilla on esim. ulkoilukalenteri, laita sen linkki tähän.",
+	},
+	helperOutdoorActivities: {
+		"fi-FI":
+			"Kuvaa hoivakodin ulkoilumahdollisuuksia. Kuvaile esim. miten ulkoilua järjestetään ja miten asiakkaat ulkoilevat.",
+		"sv-FI":
+			"Kuvaa hoivakodin ulkoilumahdollisuuksia. Kuvaile esim. miten ulkoilua järjestetään ja miten asiakkaat ulkoilevat.",
+	},
+	helperAccessibilityInfo: {
+		"fi-FI":
+			"Tähän voit tarvittaessa kirjoittaa esteettömyyttä koskevia lisätietoja.",
+		"sv-FI":
+			"Tähän voit tarvittaessa kirjoittaa esteettömyyttä koskevia lisätietoja.",
+	},
+	staffInfo: {
+		"fi-FI":
+			"Kerro halutessasi henkilöstöstä, sen rakenteesta ja erityisosaamisesta",
+		"sv-FI":
+			"Kerro halutessasi henkilöstöstä, sen rakenteesta ja erityisosaamisesta",
+	},
+	helperStaffSatisfaction: {
+		"fi-FI":
+			"Lisää linkki jos hoivakodin sivuilla on tietoa henkilöstön tyytyväisyydestä (kyselyn tulokset tms.).",
+		"sv-FI":
+			"Lisää linkki jos hoivakodin sivuilla on tietoa henkilöstön tyytyväisyydestä (kyselyn tulokset tms.).",
+	},
+	helperOtherServices: {
+		"fi-FI":
+			"Kuvaa tähän mitä muita palvelukonseptiin kuulumattomia palveluita hoivakodissa on saatavilla. Kerro myös mistä niiden hinnat löytyvät.",
+		"sv-FI":
+			"Kuvaa tähän mitä muita palvelukonseptiin kuulumattomia palveluita hoivakodissa on saatavilla. Kerro myös mistä niiden hinnat löytyvät.",
+	},
+	labelNearbyServices: {
+		"fi-FI":
+			"Hoivakodin läheltä löytyvät palvelut esim. kauppa, kirjasto, ravintola jne.",
+		"sv-FI":
+			"Hoivakodin läheltä löytyvät palvelut esim. kauppa, kirjasto, ravintola jne.",
+	},
+	labelAddImages: {
+		"fi-FI": "Lisää kuvia",
+		"sv-FI": "Lisää kuvia",
+	},
 };

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -1116,4 +1116,8 @@ export const translations = {
 		"fi-FI": "Tähdellä * merkityt kentät ovat pakollisia",
 		"sv-FI": "Tähdellä * merkityt kentät ovat pakollisia",
 	},
+	helperUrl: {
+		"fi-FI": "Esim. https://www.example.com.",
+		"sv-FI": "Esim. https://www.example.com.",
+	},
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2777,7 +2777,7 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^87.0.7:
+chromedriver@87.0.7:
   version "87.0.7"
   resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-87.0.7.tgz#74041e02ff7f633e91b98eb707e2476f713dc4ca"
   integrity sha512-7J7iN2rJuSDsKb9BUUMewJt07PuTlZYd809D10dUCT1rjMD3i2jUw7dum9RxdC1xO3aFwMd8TwZ5NR82T+S+Dg==

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1075,18 +1075,18 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nodelib/fs.scandir@2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
-  integrity sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
   dependencies:
-    "@nodelib/fs.stat" "2.0.4"
+    "@nodelib/fs.stat" "2.0.3"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.4", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz#a3f2dd61bab43b8db8fa108a121cfffe4c676655"
-  integrity sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
 
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
@@ -1094,11 +1094,11 @@
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
 "@nodelib/fs.walk@^1.2.3":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz#cce9396b30aa5afe9e3756608f5831adcb53d063"
-  integrity sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
   dependencies:
-    "@nodelib/fs.scandir" "2.1.4"
+    "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
@@ -1329,9 +1329,9 @@
     "@types/geojson" "*"
 
 "@types/node@*":
-  version "14.14.22"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.22.tgz#0d29f382472c4ccf3bd96ff0ce47daf5b7b84b18"
-  integrity sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==
+  version "12.11.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.7.tgz#57682a9771a3f7b09c2497f28129a0462966524a"
+  integrity sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==
 
 "@types/node@12.7.5":
   version "12.7.5"
@@ -1737,9 +1737,9 @@ agent-base@4, agent-base@^4.2.0, agent-base@^4.3.0:
     es6-promisify "^5.0.0"
 
 agent-base@6:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
-  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
+  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
   dependencies:
     debug "4"
 
@@ -1751,9 +1751,9 @@ agent-base@~4.2.1:
     es6-promisify "^5.0.0"
 
 aggregate-error@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
-  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
+  integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
   dependencies:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
@@ -3557,17 +3557,17 @@ debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@4.3.1, debug@^4.1.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@^4.0.1, debug@^4.1.0:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
+debug@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
   dependencies:
     ms "^2.1.1"
 
@@ -4002,17 +4002,10 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-end-of-stream@^1.0.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
-  dependencies:
-    once "^1.4.0"
-
-end-of-stream@^1.1.0:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
 
@@ -4645,11 +4638,11 @@ fast-levenshtein@~2.0.4:
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 fastq@^1.6.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.10.0.tgz#74dbefccade964932cdf500473ef302719c652bb"
-  integrity sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
+  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
   dependencies:
-    reusify "^1.0.4"
+    reusify "^1.0.0"
 
 faye-websocket@^0.10.0:
   version "0.10.0"
@@ -5083,9 +5076,9 @@ get-stream@^4.0.0:
     pump "^3.0.0"
 
 get-stream@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
-  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
   dependencies:
     pump "^3.0.0"
 
@@ -5142,9 +5135,9 @@ glob-parent@^5.0.0:
     is-glob "^4.0.1"
 
 glob-parent@^5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
-  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
   dependencies:
     is-glob "^4.0.1"
 
@@ -5165,22 +5158,10 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.4, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.3:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -5917,11 +5898,6 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
-ip-regex@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.2.0.tgz#a03f5eb661d9a154e3973a03de8b23dd0ad6892e"
-  integrity sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A==
-
 ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -6238,7 +6214,7 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-is-url@^1.2.4:
+is-url@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
   integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
@@ -6258,14 +6234,14 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is2@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.6.tgz#094f887248b49ba7ce278f8c39f85a70927bb5de"
-  integrity sha512-+Z62OHOjA6k2sUDOKXoZI3EXv7Fb1K52jpTBLbkfx62bcUeSsrTBLhEquCRDKTx0XE5XbHcG/S2vrtE3lnEDsQ==
+is2@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.1.tgz#8ac355644840921ce435d94f05d3a94634d3481a"
+  integrity sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==
   dependencies:
     deep-is "^0.1.3"
-    ip-regex "^4.1.0"
-    is-url "^1.2.4"
+    ip-regex "^2.1.0"
+    is-url "^1.2.2"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -7426,15 +7402,10 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3:
+merge2@^1.2.3, merge2@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
-
-merge2@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
-  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 methods@~1.1.2:
   version "1.1.2"
@@ -7709,15 +7680,10 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@2.1.2:
+ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-ms@^2.1.1:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -8635,10 +8601,10 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.5, picomatch@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
-  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+picomatch@^2.0.5:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
+  integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
 
 picomatch@^2.2.1:
   version "2.2.2"
@@ -10422,7 +10388,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-reusify@^1.0.4:
+reusify@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
@@ -10492,9 +10458,9 @@ run-async@^2.2.0:
     is-promise "^2.1.0"
 
 run-parallel@^1.1.9:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
-  integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -11438,12 +11404,12 @@ tar@^4:
     yallist "^3.0.3"
 
 tcp-port-used@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.2.tgz#9652b7436eb1f4cfae111c79b558a25769f6faea"
-  integrity sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.1.tgz#46061078e2d38c73979a2c2c12b5a674e6689d70"
+  integrity sha512-rwi5xJeU6utXoEIiMvVBMc9eJ2/ofzB+7nLOdnZuFTmNCLqRiQh2sMG9MqCxHU/69VC/Fwp5dV9306Qd54ll1Q==
   dependencies:
-    debug "4.3.1"
-    is2 "^2.0.6"
+    debug "4.1.0"
+    is2 "2.0.1"
 
 terser-webpack-plugin@1.4.1, terser-webpack-plugin@^1.4.1:
   version "1.4.1"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1075,18 +1075,18 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nodelib/fs.scandir@2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
-  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+"@nodelib/fs.scandir@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
+  integrity sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
   dependencies:
-    "@nodelib/fs.stat" "2.0.3"
+    "@nodelib/fs.stat" "2.0.4"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
-  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+"@nodelib/fs.stat@2.0.4", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz#a3f2dd61bab43b8db8fa108a121cfffe4c676655"
+  integrity sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
 
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
@@ -1094,11 +1094,11 @@
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
 "@nodelib/fs.walk@^1.2.3":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
-  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz#cce9396b30aa5afe9e3756608f5831adcb53d063"
+  integrity sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
   dependencies:
-    "@nodelib/fs.scandir" "2.1.3"
+    "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
@@ -1329,9 +1329,9 @@
     "@types/geojson" "*"
 
 "@types/node@*":
-  version "12.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.7.tgz#57682a9771a3f7b09c2497f28129a0462966524a"
-  integrity sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==
+  version "14.14.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.22.tgz#0d29f382472c4ccf3bd96ff0ce47daf5b7b84b18"
+  integrity sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==
 
 "@types/node@12.7.5":
   version "12.7.5"
@@ -1737,9 +1737,9 @@ agent-base@4, agent-base@^4.2.0, agent-base@^4.3.0:
     es6-promisify "^5.0.0"
 
 agent-base@6:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
-  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
 
@@ -1751,9 +1751,9 @@ agent-base@~4.2.1:
     es6-promisify "^5.0.0"
 
 aggregate-error@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
-  integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
+  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
   dependencies:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
@@ -2777,7 +2777,7 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@87.0.7:
+chromedriver@^87.0.7:
   version "87.0.7"
   resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-87.0.7.tgz#74041e02ff7f633e91b98eb707e2476f713dc4ca"
   integrity sha512-7J7iN2rJuSDsKb9BUUMewJt07PuTlZYd809D10dUCT1rjMD3i2jUw7dum9RxdC1xO3aFwMd8TwZ5NR82T+S+Dg==
@@ -3557,17 +3557,17 @@ debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@4.3.1, debug@^4.1.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.0.1, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
-
-debug@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
-  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
   dependencies:
     ms "^2.1.1"
 
@@ -4002,10 +4002,17 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.0.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  dependencies:
+    once "^1.4.0"
+
+end-of-stream@^1.1.0:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
 
@@ -4638,11 +4645,11 @@ fast-levenshtein@~2.0.4:
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 fastq@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
-  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.10.0.tgz#74dbefccade964932cdf500473ef302719c652bb"
+  integrity sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==
   dependencies:
-    reusify "^1.0.0"
+    reusify "^1.0.4"
 
 faye-websocket@^0.10.0:
   version "0.10.0"
@@ -5076,9 +5083,9 @@ get-stream@^4.0.0:
     pump "^3.0.0"
 
 get-stream@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
-  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
 
@@ -5135,9 +5142,9 @@ glob-parent@^5.0.0:
     is-glob "^4.0.1"
 
 glob-parent@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
-  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
 
@@ -5158,10 +5165,22 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.4, glob@~7.1.1:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -5898,6 +5917,11 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
+ip-regex@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.2.0.tgz#a03f5eb661d9a154e3973a03de8b23dd0ad6892e"
+  integrity sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A==
+
 ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -6214,7 +6238,7 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-is-url@^1.2.2:
+is-url@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
   integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
@@ -6234,14 +6258,14 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is2@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.1.tgz#8ac355644840921ce435d94f05d3a94634d3481a"
-  integrity sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==
+is2@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.6.tgz#094f887248b49ba7ce278f8c39f85a70927bb5de"
+  integrity sha512-+Z62OHOjA6k2sUDOKXoZI3EXv7Fb1K52jpTBLbkfx62bcUeSsrTBLhEquCRDKTx0XE5XbHcG/S2vrtE3lnEDsQ==
   dependencies:
     deep-is "^0.1.3"
-    ip-regex "^2.1.0"
-    is-url "^1.2.2"
+    ip-regex "^4.1.0"
+    is-url "^1.2.4"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -7402,10 +7426,15 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3, merge2@^1.3.0:
+merge2@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
+
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 methods@~1.1.2:
   version "1.1.2"
@@ -7680,10 +7709,15 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.1.1:
+ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -8601,10 +8635,10 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.5:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
-  integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
+picomatch@^2.0.5, picomatch@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 picomatch@^2.2.1:
   version "2.2.2"
@@ -10388,7 +10422,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-reusify@^1.0.0:
+reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
@@ -10458,9 +10492,9 @@ run-async@^2.2.0:
     is-promise "^2.1.0"
 
 run-parallel@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
-  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
+  integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -11404,12 +11438,12 @@ tar@^4:
     yallist "^3.0.3"
 
 tcp-port-used@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.1.tgz#46061078e2d38c73979a2c2c12b5a674e6689d70"
-  integrity sha512-rwi5xJeU6utXoEIiMvVBMc9eJ2/ofzB+7nLOdnZuFTmNCLqRiQh2sMG9MqCxHU/69VC/Fwp5dV9306Qd54ll1Q==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.2.tgz#9652b7436eb1f4cfae111c79b558a25769f6faea"
+  integrity sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==
   dependencies:
-    debug "4.1.0"
-    is2 "2.0.1"
+    debug "4.3.1"
+    is2 "^2.0.6"
 
 terser-webpack-plugin@1.4.1, terser-webpack-plugin@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
#### Summary
Show all nursing home data on the update page so that representatives are able to modify information themselves easily.

- PageUpdate.tsx: added different inputs, types, validation and functionality for updating the data. Moved ImageUpload component to its own file ImageUpload.tsx for readability.
- PageUpdateImages.tsx: Created new sub page for changing nursing home images. The template is same as before.
- Checkbox.tsx: Added optional onBlur property.
- Radio.tsx: Added optional onBlur and value properties.
- controllers.ts, models.tx, routes.ts: Added new route and functionality to updating nursing home information in the database.
- Added new translations

#### Dependencies
No dependencies.

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->
On development server navigate to nursing home update page. You'll need an update key for this, you can easily log it from the database for example. Test changing/adding new values to form fields and saving the data. Remember also to test the validation, by leaving some fields empty and trying to submit. Data changes should appear on the nursing home page immediately.
#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)+t#Commit-viestien-muotoilu)
- [x] The code is consistent with the existing code base
- [ ] Tests have been written for the change
- [x] All tests pass (unit, e2e)
- [x] All new code has been linted and there aren't any lint errors
- [x] The change has been tested locally, e.g., with httpie
- [x] The change has been tested in the browser with the latest Chrome
- [x] The change has been tested with a smaller screen (tablet and smartphone / emulator)
- [x] The change conforms to the UX specifications
- [ ] All translations have been added (fi and sv)
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README or inline
- [x] The branch has been rebased against dev branch before the PR was created