### PR TITLE
fix/HOIV-135-text-changes

### DIFF
--- a/frontend/src/components/FilterItem.tsx
+++ b/frontend/src/components/FilterItem.tsx
@@ -159,7 +159,7 @@ const FilterItem: FC<Props> = ({
 	};
 
 	const btnClear = useT("btnClear");
-	const btnSave = useT("btnSave");
+	const btnSelect = useT("btnSelect");
 
 	const header = values.filter((option: FilterOption) => {
 		if (option.type === "header") return true;
@@ -215,7 +215,7 @@ const FilterItem: FC<Props> = ({
 					onClick={() => setIsDropdownExpanded(false)}
 					className="btn"
 				>
-					{btnSave}
+					{btnSelect}
 				</button>
 
 				<button

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -308,6 +308,7 @@ export const translations = {
 	},
 	btnClear: { "fi-FI": "Tyhjennä", "sv-FI": "Rensa" },
 	btnSave: { "fi-FI": "Tallenna", "sv-FI": "Spara" },
+	btnSelect: { "fi-FI": "Valitse", "sv-FI": "Valitse" },
 	btnSend: { "fi-FI": "Lähetä", "sv-FI": "Skicka" },
 	summaryLabel: { "fi-FI": "hoivakotia", "sv-FI": "vårdhem" },
 	loadingText: { "fi-FI": "Ladataan...", "sv-FI": "Laddar..." },
@@ -1210,9 +1211,9 @@ export const translations = {
 	},
 	selectCommuneLabel: {
 		"fi-FI":
-			"Haku näyttää kotikuntasi asukkaile palveluita tarjoavat tehostetun palveluasumisen yksiköt",
+			"Haku näyttää kotikuntasi asukkaille palveluita tarjoavat hoivakodit",
 		"sv-FI":
-			"Sökningen visar de enheter för serviceboende med heldygnsomsorg som erbjuder tjänster för invånarna i din hemkommun",
+			"Haku näyttää kotikuntasi asukkaille palveluita tarjoavat hoivakodit",
 	},
 	charactersLeft: {
 		"fi-FI": "merkkiä jäljellä",


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->
- Fixing filter items typos and making text changes
#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [x] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)+t#Commit-viestien-muotoilu)
- [x] The code is consistent with the existing code base
- [ ] Tests have been written for the change
- [x] All tests pass (unit, e2e)
- [x] All new code has been linted and there aren't any lint errors
- [x] The change has been tested locally, e.g., with httpie
- [x] The change has been tested in the browser with the latest Chrome
- [x] The change has been tested with a smaller screen (tablet and smartphone / emulator)
- [x] The change conforms to the UX specifications
- [ ] All translations have been added (fi and sv)
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README or inline
- [x] The branch has been rebased against dev branch before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [ ] The code is consistent with the existing code base
- [ ] All changes in all changed files have been reviewed
- [ ] Tests have been written for the change
- [ ] All tests pass (unit, e2e)
- [ ] All new code has been linted and there aren't any lint errors
- [ ] The change has been tested locally, e.g., with httpie
- [ ] The change has been tested in the browser with the latest Chrome
- [ ] The change has been tested with a smaller screen (tablet and smartphone / emulator)
- [ ] The change conforms to the UX specifications
- [ ] All translations have been added (fi and sv)
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README or inline
- [ ] The PR branch has been rebased against dev branch and force pushed if necessary before merging
```
