### PR TITLE
fix/nursinghome-language-filter

### DIFF
--- a/frontend/src/components/PageNursingHomes.tsx
+++ b/frontend/src/components/PageNursingHomes.tsx
@@ -278,6 +278,28 @@ const PageNursingHomes: FC = () => {
 		citiesAndDistrictsMapFI,
 	);
 
+	const languageMapFI: Translation = {
+		[getTranslationByLanguage(
+			"sv-FI",
+			"filterFinnish",
+		)]: getTranslationByLanguage("fi-FI", "filterFinnish"),
+		[getTranslationByLanguage(
+			"sv-FI",
+			"filterSwedish",
+		)]: getTranslationByLanguage("fi-FI", "filterSwedish"),
+	};
+
+	const araMapFI: Translation = {
+		[getTranslationByLanguage(
+			"sv-FI",
+			"filterYes",
+		)]: getTranslationByLanguage("fi-FI", "filterYes"),
+		[getTranslationByLanguage(
+			"sv-FI",
+			"filterNo",
+		)]: getTranslationByLanguage("fi-FI", "filterNo"),
+	};
+
 	const hasFilters = search !== "";
 	const isFilterDisabled = nursingHomes === null;
 
@@ -307,73 +329,32 @@ const PageNursingHomes: FC = () => {
 			const filteredNursingHomes:
 				| NursingHome[]
 				| null = nursingHomes.filter(nursinghome => {
-				if (searchFilters.alue && searchFilters.alue.length > 0) {
-					const notInCorrectArea =
-						!searchFilters.alue.includes(nursinghome.district) &&
-						!searchFilters.alue.includes(nursinghome.city);
-
-					let notInCorrectAreaTranslation;
+				if (searchFilters.alue) {
+					let nursingHomeInCorrectArea;
 
 					if (currentLanguage === "sv-FI") {
-						const cityKey = Object.keys(
-							citiesAndDistrictsMapFI,
-						).find(translation => {
-							return (
-								citiesAndDistrictsMapFI[translation] ===
-									nursinghome.city ||
-								citiesAndDistrictsMapFI[translation] ===
-									nursinghome.district
+						nursingHomeInCorrectArea =
+							searchFilters.alue.includes(nursinghome.city) ||
+							searchFilters.alue.includes(nursinghome.district) ||
+							searchFilters.alue.includes(
+								citiesAndDistrictsMapFI[nursinghome.city],
+							) ||
+							searchFilters.alue.includes(
+								citiesAndDistrictsMapFI[nursinghome.district],
 							);
-						});
-
-						notInCorrectAreaTranslation = !searchFilters.alue.includes(
-							cityKey as string,
-						);
 					} else {
-						const cityKey = Object.keys(
-							citiesAndDistrictsMapSV,
-						).find(translation => {
-							return (
-								citiesAndDistrictsMapSV[translation] ===
-									nursinghome.city ||
-								citiesAndDistrictsMapSV[translation] ===
-									nursinghome.district
+						nursingHomeInCorrectArea =
+							searchFilters.alue.includes(nursinghome.city) ||
+							searchFilters.alue.includes(nursinghome.district) ||
+							searchFilters.alue.includes(
+								citiesAndDistrictsMapSV[nursinghome.city],
+							) ||
+							searchFilters.alue.includes(
+								citiesAndDistrictsMapSV[nursinghome.district],
 							);
-						});
-
-						notInCorrectAreaTranslation = !searchFilters.alue.includes(
-							cityKey as string,
-						);
 					}
 
-					if (notInCorrectArea && notInCorrectAreaTranslation) {
-						return false;
-					}
-				}
-
-				const notCorrectLanguage =
-					searchFilters.language &&
-					nursinghome.language &&
-					!nursinghome.language.includes(searchFilters.language);
-
-				if (notCorrectLanguage) {
-					return false;
-				}
-
-				const notARADestination =
-					searchFilters.ara !== undefined &&
-					((nursinghome.ara === filterYes && !searchFilters.ara) ||
-						(nursinghome.ara === filterNo && searchFilters.ara));
-
-				if (notARADestination) {
-					return false;
-				}
-
-				const notLahDestination =
-					searchFilters.lah && nursinghome.lah !== searchFilters.lah;
-
-				if (notLahDestination) {
-					return false;
+					return nursingHomeInCorrectArea;
 				}
 
 				if (searchFilters.kotikunta) {
@@ -404,9 +385,53 @@ const PageNursingHomes: FC = () => {
 						);
 					});
 
-					if (!inCorrectCommune) {
-						return false;
+					return inCorrectCommune;
+				}
+
+				if (searchFilters.language) {
+					let nursingHomeHasCorrectLanguage;
+
+					if (currentLanguage === "sv-FI") {
+						nursingHomeHasCorrectLanguage =
+							nursinghome.language &&
+							nursinghome.language.includes(
+								languageMapFI[searchFilters.language],
+							);
+					} else {
+						nursingHomeHasCorrectLanguage =
+							nursinghome.language &&
+							nursinghome.language.includes(
+								searchFilters.language,
+							);
 					}
+
+					return nursingHomeHasCorrectLanguage;
+				}
+
+				if (searchFilters.ara !== undefined) {
+					let nursingHomeIsARADestination;
+
+					if (currentLanguage === "sv-FI") {
+						nursingHomeIsARADestination =
+							nursinghome.ara !== null &&
+							searchFilters.ara === true &&
+							nursinghome.ara === araMapFI[filterYes];
+					} else {
+						nursingHomeIsARADestination =
+							nursinghome.ara !== null &&
+							searchFilters.ara === true &&
+							nursinghome.ara === filterYes;
+					}
+
+					return nursingHomeIsARADestination;
+				}
+
+				if (searchFilters.lah !== undefined) {
+					const nursingHomeHasLAH =
+						nursinghome.lah !== null &&
+						searchFilters.lah === nursinghome.lah;
+
+					return nursingHomeHasLAH;
 				}
 
 				return true;

--- a/frontend/src/components/PageNursingHomes.tsx
+++ b/frontend/src/components/PageNursingHomes.tsx
@@ -176,6 +176,10 @@ const PageNursingHomes: FC = () => {
 
 	//City or district can appear in Finnish or Swedish regardless of the current language.
 	const citiesAndDistrictsMapFI: Translation = {
+		[getTranslationByLanguage("sv-FI", "espoo")]: getTranslationByLanguage(
+			"fi-FI",
+			"espoo",
+		),
 		[getTranslationByLanguage(
 			"sv-FI",
 			"espoon keskus",
@@ -330,31 +334,49 @@ const PageNursingHomes: FC = () => {
 				| NursingHome[]
 				| null = nursingHomes.filter(nursinghome => {
 				if (searchFilters.alue) {
-					let nursingHomeInCorrectArea;
+					const nursingHomeInCorrectArea =
+						searchFilters.alue.includes(nursinghome.city) ||
+						searchFilters.alue.includes(nursinghome.district);
 
-					if (currentLanguage === "sv-FI") {
-						nursingHomeInCorrectArea =
-							searchFilters.alue.includes(nursinghome.city) ||
-							searchFilters.alue.includes(nursinghome.district) ||
-							searchFilters.alue.includes(
-								citiesAndDistrictsMapFI[nursinghome.city],
-							) ||
-							searchFilters.alue.includes(
-								citiesAndDistrictsMapFI[nursinghome.district],
-							);
-					} else {
-						nursingHomeInCorrectArea =
-							searchFilters.alue.includes(nursinghome.city) ||
-							searchFilters.alue.includes(nursinghome.district) ||
-							searchFilters.alue.includes(
-								citiesAndDistrictsMapSV[nursinghome.city],
-							) ||
-							searchFilters.alue.includes(
-								citiesAndDistrictsMapSV[nursinghome.district],
-							);
+					if (nursingHomeInCorrectArea) {
+						return true;
 					}
 
-					return nursingHomeInCorrectArea;
+					let nursingHomeInCorrectAreaTranslation;
+
+					if (currentLanguage === "sv-FI") {
+						const cityKey = Object.keys(
+							citiesAndDistrictsMapFI,
+						).find(translation => {
+							return (
+								citiesAndDistrictsMapFI[translation] ===
+									nursinghome.city ||
+								citiesAndDistrictsMapFI[translation] ===
+									nursinghome.district
+							);
+						});
+
+						nursingHomeInCorrectAreaTranslation = searchFilters.alue.includes(
+							cityKey as string,
+						);
+					} else {
+						const cityKey = Object.keys(
+							citiesAndDistrictsMapSV,
+						).find(translation => {
+							return (
+								citiesAndDistrictsMapSV[translation] ===
+									nursinghome.city ||
+								citiesAndDistrictsMapSV[translation] ===
+									nursinghome.district
+							);
+						});
+
+						nursingHomeInCorrectAreaTranslation = searchFilters.alue.includes(
+							cityKey as string,
+						);
+					}
+
+					return nursingHomeInCorrectAreaTranslation;
 				}
 
 				if (searchFilters.kotikunta) {

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -312,7 +312,7 @@ export const translations = {
 	},
 	btnClear: { "fi-FI": "Tyhjennä", "sv-FI": "Rensa" },
 	btnSave: { "fi-FI": "Tallenna", "sv-FI": "Spara" },
-	btnSelect: { "fi-FI": "Valitse", "sv-FI": "Valitse" },
+	btnSelect: { "fi-FI": "Valitse", "sv-FI": "Välj" },
 	btnSend: { "fi-FI": "Lähetä", "sv-FI": "Skicka" },
 	summaryLabel: { "fi-FI": "hoivakotia", "sv-FI": "vårdhem" },
 	loadingText: { "fi-FI": "Ladataan...", "sv-FI": "Laddar..." },


### PR DESCRIPTION
#### Summary
<!-- Describe the change, including rationale and design decisions (not just what but also why) -->
- Fix nursing home filters in Swedish
#### Dependencies
<!-- Describe the dependencies the change has on other repositories, pull requests etc. -->

#### Testing instructions
<!-- Describe how the change can be tested, e.g., steps and tools to use -->

#### Checklist for pull request creator
<!-- Check that the necessary steps have been done before the PR is created -->

- [ ] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)+t#Commit-viestien-muotoilu)
- [x] The code is consistent with the existing code base
- [ ] Tests have been written for the change
- [x] All tests pass (unit, e2e)
- [x] All new code has been linted and there aren't any lint errors
- [x] The change has been tested locally, e.g., with httpie
- [x] The change has been tested in the browser with the latest Chrome
- [x] The change has been tested with a smaller screen (tablet and smartphone / emulator)
- [x] The change conforms to the UX specifications
- [x] All translations have been added (fi and sv)
- [x] The code is self-documenting or has been documented sufficiently, e.g., in the README or inline
- [x] The branch has been rebased against dev branch before the PR was created

#### Checklist for pull request reviewer (copy to review text box)
<!-- Check that the necessary steps have been done in the review. Copy the template beneath for the review. -->

```
- [ ] A task has been created for the PR on the Kanban board with necessary details filled (one task / repo)
- [ ] The code is consistent with the existing code base
- [ ] All changes in all changed files have been reviewed
- [ ] Tests have been written for the change
- [ ] All tests pass (unit, e2e)
- [ ] All new code has been linted and there aren't any lint errors
- [ ] The change has been tested locally, e.g., with httpie
- [ ] The change has been tested in the browser with the latest Chrome
- [ ] The change has been tested with a smaller screen (tablet and smartphone / emulator)
- [ ] The change conforms to the UX specifications
- [ ] All translations have been added (fi and sv)
- [ ] The code is self-documenting or has been documented sufficiently, e.g., in the README or inline
- [ ] The PR branch has been rebased against dev branch and force pushed if necessary before merging
```
